### PR TITLE
DOTNET-4426 Early preload chaining support

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,21 +1,5 @@
 # Development
 
-## Building the Operator
-
-> Make sure to restore the submodules in the `./vendor` directory and you have the latest .NET LTS installed!
-
-The Contrast Agent Operator is a standard .NET application and can be built as such.
-
-```
-dotnet build
-```
-
-And when everything is ready,
-
-```
-dotnet run
-```
-
 ## Running the Operator Locally
 
 As this is an operator, local development requires the interactions of a K8s cluster.
@@ -49,23 +33,36 @@ https://docs.microsoft.com/en-us/visualstudio/bridge/bridge-to-kubernetes-vs-cod
 
 - Ensure `manifests\install\dev` is deployed into your local cluster.
 - Ensure the VS Code extension is installed.
+- Open the `manifests` folder in VSCode.
 - Select the operator namespace.
 
 ![Select Namespace](./assets/select-namespace.png)
 
-- Finally, create a local tunnel from the cluster to your machine. Select the port your local operator instance is running on (for us, port 5001).
-
-![Debug Service](./assets/debug-service.png)
-
-After following the prompts and running the generated task, connections for the operator wil be redirected to your local machine.
-
-To run the task:
+To run the task (Ctrl+Shift+P to open this menu):
 
 ![Run Task](./assets/run-task.png)
 
 And select the generated task:
 
 ![Bridge Task](./assets/bridge-task.png)
+
+Note: If you get the error `Error: Process 'PID 4 System Service' binds to port '443' on all addresses. This will prevent 'Bridge To Kubernetes' from forwarding network traffic on this port. Please stop this process or service and try again.` this is probably IIS binding to port 443.
+
+## Building the Operator
+
+> Make sure to restore the submodules in the `./vendor` directory and you have the latest .NET LTS installed!
+
+The Contrast Agent Operator is a standard .NET application and can be built as such.
+
+```
+dotnet build
+```
+
+And when everything is ready,
+
+```
+dotnet run
+```
 
 ## Running the Tests
 

--- a/manifests/examples/dev/cluster-defaults.yaml
+++ b/manifests/examples/dev/cluster-defaults.yaml
@@ -10,8 +10,6 @@ spec:
         enabled: true
         agent:
           dotnet:
-            secret:
-              should_connect: false
             test: false
   namespaces:
     - default

--- a/manifests/examples/dev/minimal-setup.yaml
+++ b/manifests/examples/dev/minimal-setup.yaml
@@ -136,7 +136,3 @@ metadata:
 spec:
   yaml: |
     enabled: true
-    agent:
-      dotnet:
-        secret:
-          should_connect: false

--- a/manifests/examples/openshift/base/minimal-setup.yaml
+++ b/manifests/examples/openshift/base/minimal-setup.yaml
@@ -52,7 +52,3 @@ metadata:
 spec:
   yaml: |
     enabled: true
-    agent:
-      dotnet:
-        secret:
-          should_connect: false

--- a/manifests/generate-manifests.ps1
+++ b/manifests/generate-manifests.ps1
@@ -34,6 +34,7 @@ dotnet run --no-build --project $project -- generator rbac -o $output\rbac\
     # "$($output)operator\ca.pem"
     # "$($output)operator\kustomization.yaml"
     "$($output)crd\deploymentconfigs_apps_openshift_io.yaml"
+    "$($output)crd\dynakubes_dynatrace_com.yaml"
     "$($output)crd\kustomization.yaml"
 ) | ForEach-Object {
     Write-Host "Cleaning up bad object $_"

--- a/manifests/install/all/base/rbac/cluster-role.yaml
+++ b/manifests/install/all/base/rbac/cluster-role.yaml
@@ -32,14 +32,12 @@ rules:
 - apiGroups:
   - apps
   - ""
-  - dynatrace.com
   - apps.openshift.io
   resources:
   - daemonsets
   - deployments
   - statefulsets
   - pods
-  - dynakubes
   - deploymentconfigs
   verbs:
   - get
@@ -54,8 +52,10 @@ rules:
   - '*'
 - apiGroups:
   - agents.contrastsecurity.com
+  - dynatrace.com
   resources:
   - clusteragentconnections
+  - dynakubes
   - clusteragentconfigurations
   verbs:
   - get

--- a/manifests/install/all/base/rbac/cluster-role.yaml
+++ b/manifests/install/all/base/rbac/cluster-role.yaml
@@ -8,42 +8,12 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - apps
-  - apps.openshift.io
-  resources:
-  - pods
-  - daemonsets
-  - deploymentconfigs
-  - deployments
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
   - agents.contrastsecurity.com
-  resources:
-  - clusteragentconfigurations
-  - clusteragentconnections
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - agents.contrastsecurity.com
-  resources:
-  - agentinjectors
-  verbs:
-  - '*'
-- apiGroups:
-  - agents.contrastsecurity.com
-  - ""
   - coordination.k8s.io
   resources:
-  - agentconfigurations
   - secrets
   - agentconnections
+  - agentconfigurations
   - leases
   verbs:
   - '*'
@@ -59,6 +29,38 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - apps
+  - ""
+  - dynatrace.com
+  - apps.openshift.io
+  resources:
+  - daemonsets
+  - deployments
+  - statefulsets
+  - pods
+  - dynakubes
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - agents.contrastsecurity.com
+  resources:
+  - agentinjectors
+  verbs:
+  - '*'
+- apiGroups:
+  - agents.contrastsecurity.com
+  resources:
+  - clusteragentconnections
+  - clusteragentconfigurations
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -81,14 +83,6 @@ rules:
   - update
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - pods/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - apps
   resources:
   - daemonsets/status
@@ -108,6 +102,14 @@ rules:
   - apps
   resources:
   - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
   verbs:
   - get
   - patch

--- a/manifests/install/dev/kustomization.yaml
+++ b/manifests/install/dev/kustomization.yaml
@@ -1,10 +1,5 @@
 bases:
   - ../all
 
-images:
-  - name: contrast/agent-operator
-    newName: contrastdotnet.azurecr.io/agent-operator/agent-operator
-    newTag: latest
-
 patchesStrategicMerge:
   - overlays/deployment.yaml

--- a/manifests/install/dev/overlays/deployment.yaml
+++ b/manifests/install/dev/overlays/deployment.yaml
@@ -7,12 +7,8 @@ spec:
   replicas: 1
   template:
     spec:
-      imagePullSecrets:
-       - name: contrastdotnet-pull-secret
       containers:
         - name: contrast-agent-operator
           env:
-            - name: CONTRAST_DEFAULT_REGISTRY
-              value: contrastdotnet.azurecr.io/agent-operator
             - name: CONTRAST_AGENT_TELEMETRY_OPTOUT
               value: "true"

--- a/manifests/install/examples/classicfullstack-chaining/README.md
+++ b/manifests/install/examples/classicfullstack-chaining/README.md
@@ -1,3 +1,5 @@
 # Examples: Dynatrace Classic Full Stack Chaining
 
-TODO
+The Agent Operator supports chaining the .NET Core Contrast Agent with Dynatrace's operator but requires extra configuration if using Dynatrace's operator in `classicFullStack` mode
+
+This is an example of how to set `CONTRAST_ENABLE_EARLY_CHAINING=true` on the operator to support chaining `classicFullStack` mode.

--- a/manifests/install/examples/classicfullstack-chaining/README.md
+++ b/manifests/install/examples/classicfullstack-chaining/README.md
@@ -1,0 +1,3 @@
+# Examples: Dynatrace Classic Full Stack Chaining
+
+TODO

--- a/manifests/install/examples/classicfullstack-chaining/kustomization.yaml
+++ b/manifests/install/examples/classicfullstack-chaining/kustomization.yaml
@@ -1,0 +1,20 @@
+namespace: contrast-agent-operator
+bases:
+  - ../../all
+
+patchesStrategicMerge:
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: contrast-agent-operator
+      namespace: contrast-agent-operator
+    spec:
+      template:
+        spec:
+          containers:
+            - name: contrast-agent-operator
+              env:
+                - name: CONTRAST_ENABLE_EARLY_CHAINING
+                  value: "true"
+

--- a/src/Contrast.K8s.AgentOperator/Controllers/DynaKubeController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/DynaKubeController.cs
@@ -9,7 +9,7 @@ using KubeOps.Operator.Rbac;
 
 namespace Contrast.K8s.AgentOperator.Controllers
 {
-    [EntityRbac(typeof(V1Beta1DynaKube), Verbs = VerbConstants.ReadAndPatch), UsedImplicitly]
+    [EntityRbac(typeof(V1Beta1DynaKube), Verbs = VerbConstants.ReadOnly), UsedImplicitly]
     public class DynaKubeController : GenericController<V1Beta1DynaKube>
     {
         public DynaKubeController(IEventStream eventStream) : base(eventStream)

--- a/src/Contrast.K8s.AgentOperator/Controllers/DynaKubeController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/DynaKubeController.cs
@@ -1,0 +1,19 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Contrast.K8s.AgentOperator.Core.Kube;
+using Contrast.K8s.AgentOperator.Core.State;
+using Contrast.K8s.AgentOperator.Entities.Dynatrace;
+using JetBrains.Annotations;
+using KubeOps.Operator.Rbac;
+
+namespace Contrast.K8s.AgentOperator.Controllers
+{
+    [EntityRbac(typeof(V1Beta1DynaKube), Verbs = VerbConstants.ReadAndPatch), UsedImplicitly]
+    public class DynaKubeController : GenericController<V1Beta1DynaKube>
+    {
+        public DynaKubeController(IEventStream eventStream) : base(eventStream)
+        {
+        }
+    }
+}

--- a/src/Contrast.K8s.AgentOperator/Core/Chaining/DynaKubeHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Chaining/DynaKubeHandler.cs
@@ -1,0 +1,43 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Contrast.K8s.AgentOperator.Core.Events;
+using Contrast.K8s.AgentOperator.Entities.Dynatrace;
+using Contrast.K8s.AgentOperator.Options;
+using JetBrains.Annotations;
+using k8s.Models;
+using MediatR;
+using NLog;
+
+namespace Contrast.K8s.AgentOperator.Core.Chaining
+{
+    [UsedImplicitly]
+    public class DynaKubeHandler : INotificationHandler<EntityReconciled<V1Beta1DynaKube>>
+    {
+        private readonly InjectorOptions _injectorOptions;
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public DynaKubeHandler(InjectorOptions injectorOptions)
+        {
+            _injectorOptions = injectorOptions;
+        }
+
+        public Task Handle(EntityReconciled<V1Beta1DynaKube> notification, CancellationToken cancellationToken)
+        {
+            if (!_injectorOptions.EnableEarlyChaining)
+            {
+                var oneAgentSpec = notification.Entity.Spec.OneAgent;
+                if (oneAgentSpec?.ClassicFullStack != null)
+                {
+                    Logger.Warn(
+                        $"Dynatrace Operator is present and in classicFullStack mode. Please set the environment variable 'CONTRAST_ENABLE_EARLY_CHAINING=true' on the operator and restart the affected pods.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
@@ -5,19 +5,34 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Primitives;
+using Contrast.K8s.AgentOperator.Options;
 using k8s.Models;
 
 namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
 {
     public class DotNetAgentPatcher : IAgentPatcher
     {
+        private readonly InjectorOptions _injectorOptions;
         public AgentInjectionType Type => AgentInjectionType.DotNetCore;
+
+        public DotNetAgentPatcher(InjectorOptions injectorOptions)
+        {
+            _injectorOptions = injectorOptions;
+        }
 
         public IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context)
         {
-            yield return new V1EnvVar("CORECLR_PROFILER", "{8B2CE134-0948-48CA-A4B2-80DDAD9F5791}");
-            yield return new V1EnvVar("CORECLR_PROFILER_PATH", $"{context.ContrastMountPath}/runtimes/linux-x64/native/ContrastProfiler.so");
-            yield return new V1EnvVar("CORECLR_ENABLE_PROFILING", "1");
+            if (_injectorOptions.EnableEarlyChaining)
+            {
+                yield return new V1EnvVar("LD_PRELOAD",
+                    $"{context.ContrastMountPath}/runtimes/linux-x64/native/ContrastChainLoader.so");
+            }
+            else
+            {
+                yield return new V1EnvVar("CORECLR_PROFILER", "{8B2CE134-0948-48CA-A4B2-80DDAD9F5791}");
+                yield return new V1EnvVar("CORECLR_PROFILER_PATH", $"{context.ContrastMountPath}/runtimes/linux-x64/native/ContrastProfiler.so");
+                yield return new V1EnvVar("CORECLR_ENABLE_PROFILING", "1");
+            }
             yield return new V1EnvVar("CONTRAST_SOURCE", "kubernetes-operator");
             yield return new V1EnvVar("CONTRAST_CORECLR_INSTALL_DIRECTORY", context.ContrastMountPath);
             yield return new V1EnvVar("CONTRAST__AGENT__DOTNET__ENABLE_FILE_WATCHING", "false");
@@ -34,10 +49,11 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
                 StringComparison.OrdinalIgnoreCase
             );
 
-            // Only modify this if CONTRAST_EXISTING_LD_PRELOAD isn't already set. This is to prevent infinite loops.
+            // Only modify this if CONTRAST_EXISTING_LD_PRELOAD isn't already set, or we are not already set from early chaining. This is to prevent infinite loops.
             if (chainingEnabled
                 && GetFirstOrDefaultEnvVar(container.Env, "LD_PRELOAD") is { Value: { } currentLdPreloadValue }
                 && !string.IsNullOrWhiteSpace(currentLdPreloadValue)
+                && !currentLdPreloadValue.Contains("ContrastChainLoader.so", StringComparison.OrdinalIgnoreCase)
                 && GetFirstOrDefaultEnvVar(container.Env, "CONTRAST_EXISTING_LD_PRELOAD") is null)
             {
                 container.Env.AddOrUpdate(new V1EnvVar("CONTRAST_EXISTING_LD_PRELOAD", currentLdPreloadValue));

--- a/src/Contrast.K8s.AgentOperator/Entities/Dynatrace/V1Beta1DynaKube.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/Dynatrace/V1Beta1DynaKube.cs
@@ -1,0 +1,41 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+using k8s.Models;
+using KubeOps.Operator.Entities;
+
+namespace Contrast.K8s.AgentOperator.Entities.Dynatrace
+{
+    [KubernetesEntity(Group = "dynatrace.com", ApiVersion = "v1beta1", Kind = "DynaKube", PluralName = "dynakubes"), UsedImplicitly]
+    public class V1Beta1DynaKube : CustomKubernetesEntity<V1Beta1DynaKube.DynaKubeSpec>
+    {
+        /// <summary>
+        /// DynaKubeSpec represents the dynatrace operator config
+        /// </summary>
+        public class DynaKubeSpec
+        {
+            /// <summary>
+            /// OneAgent Config
+            /// </summary>
+            [JsonPropertyName("oneAgent")]
+            public OneAgentSpec? OneAgent { get; set; }
+        }
+    }
+
+    public class OneAgentSpec
+    {
+        [JsonPropertyName("classicFullStack")]
+        public object? ClassicFullStack { get; set; }
+
+        [JsonPropertyName("applicationMonitoring")]
+        public object? ApplicationMonitoring { get; set; }
+
+        [JsonPropertyName("hostMonitoring")]
+        public object? HostMonitoring { get; set; }
+
+        [JsonPropertyName("cloudNativeFullStack")]
+        public object? CloudNativeFullStack { get; set; }
+    }
+}

--- a/src/Contrast.K8s.AgentOperator/Options/InjectorOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/InjectorOptions.cs
@@ -1,0 +1,7 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Contrast.K8s.AgentOperator.Options
+{
+    public record InjectorOptions(bool EnableEarlyChaining = false);
+}

--- a/src/Contrast.K8s.AgentOperator/Program.cs
+++ b/src/Contrast.K8s.AgentOperator/Program.cs
@@ -28,7 +28,7 @@ namespace Contrast.K8s.AgentOperator
 
             try
             {
-                logger.Info($"Starting the Contrast Secruity Agent Operator {OperatorVersion.Version}.");
+                logger.Info($"Starting the Contrast Security Agent Operator {OperatorVersion.Version}.");
 
                 return await CreateHostBuilder(args)
                              .Build()

--- a/src/Contrast.K8s.AgentOperator/Properties/launchSettings.json
+++ b/src/Contrast.K8s.AgentOperator/Properties/launchSettings.json
@@ -6,7 +6,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "POD_NAMESPACE": "contrast-agent-operator",
         "CONTRAST_WEBHOOK_HOSTS": "contrast-agent-operator,contrast-agent-operator.contrast-agent-operator.svc,contrast-agent-operator.contrast-agent-operator.svc.cluster.local",
-        "CONTRAST_DEFAULT_REGISTRY": "contrastdotnet.azurecr.io/agent-operator",
+        "CONTRAST_DEFAULT_REGISTRY": "contrast",
         "CONTRAST_SETTLE_DURATION": "2",
         "CONTRAST_DEVELOPMENT": "true"
       },

--- a/src/Contrast.K8s.AgentOperator/Startup.cs
+++ b/src/Contrast.K8s.AgentOperator/Startup.cs
@@ -205,6 +205,20 @@ namespace Contrast.K8s.AgentOperator
                 var @namespace = x.Resolve<OperatorOptions>().Namespace;
                 return new TelemetryOptions("contrast-cluster-id", @namespace);
             }).SingleInstance();
+
+            builder.Register(_ =>
+            {
+                if (Environment.GetEnvironmentVariable("CONTRAST_ENABLE_EARLY_CHAINING") is { } earlyChaining)
+                {
+                    if (earlyChaining.Equals("1", StringComparison.OrdinalIgnoreCase)
+                        || earlyChaining.Equals("true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new InjectorOptions(true);
+                    }
+                }
+
+                return new InjectorOptions();
+            }).SingleInstance();
         }
     }
 }

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using AutoFixture;
 using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching;
 using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents;
+using Contrast.K8s.AgentOperator.Options;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using k8s.Models;
@@ -20,7 +21,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
         [Fact]
         public void GenerateEnvVars_should_return_profiling_vars()
         {
-            var patcher = new DotNetAgentPatcher();
+            var patcher = new DotNetAgentPatcher(new InjectorOptions());
             var context = AutoFixture.Create<PatchingContext>();
             var expectedEnvVars = new List<string>
             {
@@ -39,10 +40,31 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
             result.Should().Equal(expectedEnvVars, (source, expected) => source.Name == expected);
         }
 
+
+        [Fact]
+        public void GenerateEnvVars_should_return_ldpreload_if_early_chaining()
+        {
+            var patcher = new DotNetAgentPatcher(new InjectorOptions(true));
+            var context = AutoFixture.Create<PatchingContext>();
+            var expectedEnvVars = new List<string>
+            {
+                "LD_PRELOAD",
+                "CONTRAST_SOURCE",
+                "CONTRAST_CORECLR_INSTALL_DIRECTORY",
+                "CONTRAST__AGENT__DOTNET__ENABLE_FILE_WATCHING"
+            };
+
+            // Act
+            var result = patcher.GenerateEnvVars(context).ToList();
+
+            // Assert
+            result.Should().Equal(expectedEnvVars, (source, expected) => source.Name == expected);
+        }
+
         [Fact]
         public void PatchContainer_should_add_ld_preload_if_already_set()
         {
-            var patcher = new DotNetAgentPatcher();
+            var patcher = new DotNetAgentPatcher(new InjectorOptions());
             var context = AutoFixture.Create<PatchingContext>();
             var existingPreload = AutoFixture.Create<string>();
             var container = AutoFixture.Build<V1Container>()
@@ -65,7 +87,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
         [Fact]
         public void PatchContainer_should_not_do_anything_if_chaining_disabled()
         {
-            var patcher = new DotNetAgentPatcher();
+            var patcher = new DotNetAgentPatcher(new InjectorOptions());
             var context = AutoFixture.Create<PatchingContext>();
             var container = AutoFixture.Build<V1Container>().With(x => x.Env,
                 new List<V1EnvVar> { new("CONTRAST__AGENT__DOTNET__ENABLE_CHAINING", "false") }).Create();
@@ -78,6 +100,26 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
             {
                 container.Env.Should().NotContain(x => x.Name == "CONTRAST_EXISTING_LD_PRELOAD");
                 container.Env.Should().NotContain(x => x.Name == "LD_PRELOAD");
+            }
+        }
+
+        [Fact]
+        public void PatchContainer_should_not_do_anything_if_we_already_injected_early()
+        {
+            var patcher = new DotNetAgentPatcher(new InjectorOptions(true));
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingPreload = AutoFixture.Create<string>() + "ContrastChainLoader.so";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("LD_PRELOAD", existingPreload) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                container.Env.Should().NotContain(x => x.Name == "CONTRAST_EXISTING_LD_PRELOAD");
+                container.Env.Should().Contain(x => x.Name == "LD_PRELOAD" && x.Value == existingPreload);
             }
         }
     }


### PR DESCRIPTION
Adds support for detecting dynatrace's classicFullStack mode and instructs the user to set CONTRAST_ENABLE_EARLY_CHAINING on the operator.

This will cause LD_PRELOAD for our ContrastChainLoader to be set during the initial pod patching. This will cause dynatrace in cloudNativeFullStack or applicationMonitoring mode to no longer chain so this is an opt-in setting.

This PR also updates the docs for local development and adds an example of setting CONTRAST_ENABLE_EARLY_CHAINING