### PR TITLE
DOTNET-4544 Add support for patching existing JAVA_TOOL_OPTIONS

### DIFF
--- a/manifests/examples/testing/scenarios/namespaced/injection-java-tooloptions.yaml
+++ b/manifests/examples/testing/scenarios/namespaced/injection-java-tooloptions.yaml
@@ -1,0 +1,42 @@
+apiVersion: agents.contrastsecurity.com/v1beta1
+kind: AgentInjector
+metadata:
+  name: injection-java-tooloptions
+spec:
+  enabled: true
+  type: java
+  selector:
+    labels:
+      - name: app
+        value: injection-java-tooloptions
+  image:
+    pullPolicy: Never
+  connection:
+    name: testing-agent-connection
+  configuration:
+    name: testing-agent-configuration
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: injection-java-tooloptions
+  labels:
+    app: injection-java-tooloptions
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: injection-java-tooloptions
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: injection-java-tooloptions
+    spec:
+      containers:
+        - image: k8s.gcr.io/pause:3.3
+          name: pause
+          env:
+            - name: JAVA_TOOL_OPTIONS
+              value: something

--- a/manifests/examples/testing/scenarios/namespaced/injection-javatooloptions.yaml
+++ b/manifests/examples/testing/scenarios/namespaced/injection-javatooloptions.yaml
@@ -1,14 +1,14 @@
 apiVersion: agents.contrastsecurity.com/v1beta1
 kind: AgentInjector
 metadata:
-  name: injection-java-tooloptions
+  name: injection-javatooloptions
 spec:
   enabled: true
   type: java
   selector:
     labels:
       - name: app
-        value: injection-java-tooloptions
+        value: injection-javatooloptions
   image:
     pullPolicy: Never
   connection:
@@ -19,20 +19,20 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: injection-java-tooloptions
+  name: injection-javatooloptions
   labels:
-    app: injection-java-tooloptions
+    app: injection-javatooloptions
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: injection-java-tooloptions
+      app: injection-javatooloptions
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: injection-java-tooloptions
+        app: injection-javatooloptions
     spec:
       containers:
         - image: k8s.gcr.io/pause:3.3

--- a/manifests/examples/testing/scenarios/namespaced/kustomization.yaml
+++ b/manifests/examples/testing/scenarios/namespaced/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   - ./injection-dotnetchaining.yaml
   - ./injection-dummy.yaml
   - ./injection-java.yaml
-  - ./injection-java-tooloptions.yaml
+  - ./injection-javatooloptions.yaml
   - ./injection-nodejs.yaml
   - ./injection-php.yaml
   - ./missing-deps.yaml

--- a/manifests/examples/testing/scenarios/namespaced/kustomization.yaml
+++ b/manifests/examples/testing/scenarios/namespaced/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./injection-dotnetchaining.yaml
   - ./injection-dummy.yaml
   - ./injection-java.yaml
+  - ./injection-java-tooloptions.yaml
   - ./injection-nodejs.yaml
   - ./injection-php.yaml
   - ./missing-deps.yaml

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcher.cs
@@ -36,7 +36,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
                 {
                     var options = JavaArgumentParser.ParseArguments(currentJavaToolOptions).ToList();
                     //Patch contrast-agent.jar to the correct path
-                    var contrastJavaAgentIndex = options.FindIndex(x => x.StartsWith("-javaagent") && x.Contains("contrast-agent.jar"));
+                    var contrastJavaAgentIndex = options.FindIndex(x => x.StartsWith("-javaagent", StringComparison.OrdinalIgnoreCase) && x.Contains("contrast-agent.jar", StringComparison.OrdinalIgnoreCase));
                     if (contrastJavaAgentIndex >= 0)
                     {
                         options[contrastJavaAgentIndex] = contrastAgentArgument;
@@ -49,7 +49,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
                 }
                 catch (Exception e)
                 {
-                    Logger.Warn($"Failed to parse existing JAVA_TOOL_OPTIONS, unable to patch!: {e}");
+                    Logger.Warn(e, $"Failed to parse existing JAVA_TOOL_OPTIONS, unable to patch!");
                 }
             }
         }

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcher.cs
@@ -1,21 +1,67 @@
 ﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Primitives;
 using k8s.Models;
+using NLog;
 
 namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
 {
     public class JavaAgentPatcher : IAgentPatcher
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public AgentInjectionType Type => AgentInjectionType.Java;
 
         public IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context)
         {
-            yield return new V1EnvVar("JAVA_TOOL_OPTIONS", $"-javaagent:{context.ContrastMountPath}/contrast-agent.jar");
+            yield return new V1EnvVar("JAVA_TOOL_OPTIONS", GetContrastAgentArgument(context));
         }
 
+        public void PatchContainer(V1Container container, PatchingContext context)
+        {
+            if (GetFirstOrDefaultEnvVar(container.Env, "JAVA_TOOL_OPTIONS") is { Value: { } currentJavaToolOptions }
+                && !string.IsNullOrWhiteSpace(currentJavaToolOptions)
+                && !currentJavaToolOptions.EndsWith("contrast-agent.jar", StringComparison.OrdinalIgnoreCase)
+                && GetFirstOrDefaultEnvVar(container.Env, "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS") is null)
+            {
+                var contrastAgentArgument = GetContrastAgentArgument(context);
+                //Parse and patch the existing JAVA_TOOL_OPTIONS
+                container.Env.AddOrUpdate(new V1EnvVar("CONTRAST_EXISTING_JAVA_TOOL_OPTIONS", currentJavaToolOptions));
+                try
+                {
+                    var options = JavaArgumentParser.ParseArguments(currentJavaToolOptions).ToList();
+                    //Patch contrast-agent.jar to the correct path
+                    var contrastJavaAgentIndex = options.FindIndex(x => x.StartsWith("-javaagent") && x.Contains("contrast-agent.jar"));
+                    if (contrastJavaAgentIndex >= 0)
+                    {
+                        options[contrastJavaAgentIndex] = contrastAgentArgument;
+                    }
+                    else //contrast-agent.jar is not in the arguments so just prepend it
+                    {
+                        options.Insert(0, contrastAgentArgument);
+                    }
+                    container.Env.AddOrUpdate(new V1EnvVar("JAVA_TOOL_OPTIONS", string.Join(' ', options)));
+                }
+                catch (Exception e)
+                {
+                    Logger.Warn($"Failed to parse existing JAVA_TOOL_OPTIONS, unable to patch!: {e}");
+                }
+            }
+        }
+
+        private static V1EnvVar? GetFirstOrDefaultEnvVar(IEnumerable<V1EnvVar> collection, string name)
+        {
+            return collection.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private string GetContrastAgentArgument(PatchingContext context) => $"-javaagent:{context.ContrastMountPath}/contrast-agent.jar";
+
         public string GetMountPath() => "/opt/contrast";
+
     }
 }

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParser.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParser.cs
@@ -1,0 +1,140 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility
+{
+    public static class JavaArgumentParser
+    {
+        /* https://docs.oracle.com/en/java/javase/17/docs/specs/jvmti.html#tooloptions
+         * JAVA_TOOL_OPTIONS variable will be broken into options at white-space boundaries.
+         * White-space characters include space, tab, carriage-return, new-line, vertical-tab, and form-feed.
+         * Sequences of white-space characters are considered equivalent to a single white-space character.
+         * No white-space is included in the options unless quoted.
+         * Quoting is as follows:
+         *  
+         *  All characters enclosed between a pair of single quote marks (''), except a single quote, are quoted.
+         *  Double quote characters have no special meaning inside a pair of single quote marks.
+         *  All characters enclosed between a pair of double quote marks (""), except a double quote, are quoted.
+         *  Single quote characters have no special meaning inside a pair of double quote marks.
+         *  A quoted part can start or end anywhere in the variable.
+         *  White-space characters have no special meaning when quoted -- they are included in the option like any other character and do not mark white-space boundaries.
+         *  The pair of quote marks is not included in the option.
+         */
+
+        public static IEnumerable<string> ParseArguments(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                yield break;
+            }
+
+            var state = State.Unknown;
+            var wordStart = 0;
+            var wordLength = 0;
+            var currentQuote = '\0';
+
+            var workspace = input.ToCharArray();
+
+            var i = 0;
+            while (i < input.Length)
+            {
+                var c = workspace[i];
+
+                switch (state)
+                {
+                    case State.InBoundary:
+                    case State.Unknown:
+                        if (IsQuote(c))
+                        {
+                            wordStart = i;
+                            wordLength = 0;
+                            currentQuote = c;
+                            state = State.InQuotedWord;
+                        }
+                        else if (IsWhitespace(c))
+                        {
+                            state = State.InBoundary;
+                        }
+                        else
+                        {
+                            wordStart = i;
+                            wordLength = 0;
+                            state = State.InWord;
+                        }
+
+                        break;
+                    case State.InQuotedWord:
+                        wordLength++;
+                        if (c == currentQuote)
+                        {
+                            state = State.InWord;
+                        }
+
+                        break;
+                    case State.InWord:
+                        wordLength++;
+                        if (IsQuote(c))
+                        {
+                            currentQuote = c;
+                            state = State.InQuotedWord;
+                        }
+                        else if (IsWhitespace(c))
+                        {
+                            state = State.InBoundary;
+
+                            yield return input.Substring(wordStart, wordLength);
+                        }
+
+                        break;
+                    case State.EndOfInput:
+                        wordLength++;
+                        if (!IsWhitespace(c))
+                        {
+                            yield return input.Substring(wordStart, wordLength);
+                        }
+
+                        yield break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                if (i + 1 == input.Length)
+                {
+                    if (state == State.InQuotedWord)
+                    {
+                        throw new Exception("Unmatched quote in arguments");
+                    }
+                    state = State.EndOfInput;
+                }
+                else
+                {
+                    i++;
+                }
+            }
+        }
+
+        private static bool IsQuote(char c)
+        {
+            return c == '"' || c == '\'';
+        }
+
+        private static bool IsWhitespace(char c)
+        {
+            return (c >= 0x9 && c <= 0xD) || c == 0x20; //(tab, carriage-return, new-line, vertical-tab, and form-feed) or space
+        }
+
+        private enum State
+        {
+            Unknown,
+            InBoundary,
+            InQuotedWord,
+            InWord,
+            EndOfInput
+        }
+
+    }
+
+}

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParser.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParser.cs
@@ -105,7 +105,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility
                 {
                     if (state == State.InQuotedWord)
                     {
-                        throw new Exception("Unmatched quote in arguments");
+                        throw new JavaArgumentParserException("Unmatched quote in arguments");
                     }
                     state = State.EndOfInput;
                 }
@@ -135,6 +135,23 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility
             EndOfInput
         }
 
+
+    }
+    public class JavaArgumentParserException : Exception
+    {
+        public JavaArgumentParserException()
+        {
+        }
+
+        public JavaArgumentParserException(string message)
+            : base(message)
+        {
+        }
+
+        public JavaArgumentParserException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
     }
 
 }

--- a/src/Contrast.K8s.AgentOperator/Core/Telemetry/Services/Exceptions/TelemetryExceptionsTarget.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Telemetry/Services/Exceptions/TelemetryExceptionsTarget.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility;
 using Contrast.K8s.AgentOperator.Core.Telemetry.Models;
 using k8s.Autorest;
 using NLog;
@@ -37,6 +38,7 @@ namespace Contrast.K8s.AgentOperator.Core.Telemetry.Services.Exceptions
         {
             switch (exception)
             {
+                case JavaArgumentParserException:
                 case HttpOperationException httpOperationException
                     when httpOperationException.Response.StatusCode is not HttpStatusCode.BadRequest:
                 case HttpRequestException { InnerException: IOException }:

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/JavaToolOptionsInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/JavaToolOptionsInjectionTests.cs
@@ -12,7 +12,7 @@ namespace Contrast.K8s.AgentOperator.FunctionalTests.Scenarios.Injection.Agents
 {
     public class JavaToolOptionsInjectionTests : IClassFixture<TestingContext>
     {
-        private const string ScenarioName = "injection-java-tooloptions";
+        private const string ScenarioName = "injection-javatooloptions";
 
         private readonly TestingContext _context;
 

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/JavaToolOptionsInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/JavaToolOptionsInjectionTests.cs
@@ -1,0 +1,45 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Contrast.K8s.AgentOperator.FunctionalTests.Fixtures;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Contrast.K8s.AgentOperator.FunctionalTests.Scenarios.Injection.Agents
+{
+    public class JavaToolOptionsInjectionTests : IClassFixture<TestingContext>
+    {
+        private const string ScenarioName = "injection-java-tooloptions";
+
+        private readonly TestingContext _context;
+
+        public JavaToolOptionsInjectionTests(TestingContext context, ITestOutputHelper outputHelper)
+        {
+            _context = context;
+            _context.RegisterOutput(outputHelper);
+        }
+
+        [Fact]
+        public async Task When_injected_then_pod_should_have_patched_java_tool_options_environment_variable()
+        {
+            var client = await _context.GetClient();
+
+            // Act
+            var result = await client.GetInjectedPodByPrefix(ScenarioName);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                var container = result.Spec.Containers.Should().ContainSingle().Subject;
+
+                container.Env.Should().Contain(x => x.Name == "JAVA_TOOL_OPTIONS")
+                    .Which.Value.Should().Be("-javaagent:/opt/contrast/contrast-agent.jar something");
+                container.Env.Should().Contain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS")
+                    .Which.Value.Should().Be("something");
+            }
+        }
+    }
+}

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/JavaAgentPatcherTests.cs
@@ -7,6 +7,7 @@ using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching;
 using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Primitives;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using k8s.Models;
 using Xunit;
 
@@ -55,5 +56,117 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
                 new("JAVA_TOOL_OPTIONS", $"-javaagent:{contextFake.ContrastMountPath}/contrast-agent.jar")
             });
         }
+
+        [Fact]
+        public void PatchContainer_should_not_do_anything_if_we_already_injected()
+        {
+            var patcher = new JavaAgentPatcher();
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingToolOptions = "-javaagent:/somepath/contrast-agent.jar";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("JAVA_TOOL_OPTIONS", existingToolOptions) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                container.Env.Should().NotContain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS");
+                container.Env.Should().Contain(x => x.Name == "JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+            }
+        }
+
+        [Fact]
+        public void PatchContainer_should_handle_existing_javaagent()
+        {
+            var patcher = new JavaAgentPatcher();
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingToolOptions = "-javaagent:/somepath/some-tool.jar -Dcontrast.dir=/tmp";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("JAVA_TOOL_OPTIONS", existingToolOptions) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            var expectedToolOptions = $"-javaagent:{context.ContrastMountPath}/contrast-agent.jar -javaagent:/somepath/some-tool.jar -Dcontrast.dir=/tmp";
+            using (new AssertionScope())
+            {
+                container.Env.Should()
+                    .Contain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+                container.Env.Should()
+                    .Contain(x => x.Name == "JAVA_TOOL_OPTIONS" && x.Value == expectedToolOptions);
+            }
+        }
+
+        [Fact]
+        public void PatchContainer_should_handle_existing_correct_contrast_javaagent()
+        {
+            var patcher = new JavaAgentPatcher();
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingToolOptions = "-javaagent:/somepath/contrast-agent.jar -Dcontrast.dir=/tmp";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("JAVA_TOOL_OPTIONS", existingToolOptions) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            var expectedToolOptions = $"-javaagent:{context.ContrastMountPath}/contrast-agent.jar -Dcontrast.dir=/tmp";
+            using (new AssertionScope())
+            {
+                container.Env.Should()
+                    .Contain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+                container.Env.Should()
+                    .Contain(x => x.Name == "JAVA_TOOL_OPTIONS" && x.Value == expectedToolOptions);
+            }
+        }
+
+        [Fact]
+        public void PatchContainer_should_handle_no_javaagent()
+        {
+            var patcher = new JavaAgentPatcher();
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingToolOptions = "-Dcontrast.dir=/tmp";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("JAVA_TOOL_OPTIONS", existingToolOptions) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            var expectedToolOptions = $"-javaagent:{context.ContrastMountPath}/contrast-agent.jar -Dcontrast.dir=/tmp";
+            using (new AssertionScope())
+            {
+                container.Env.Should()
+                    .Contain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+                container.Env.Should()
+                    .Contain(x => x.Name == "JAVA_TOOL_OPTIONS" && x.Value == expectedToolOptions);
+            }
+        }
+
+        [Fact]
+        public void PatchContainer_should_not_patch_on_malformed_options()
+        {
+            var patcher = new JavaAgentPatcher();
+            var context = AutoFixture.Create<PatchingContext>();
+            var existingToolOptions = "-Dcontrast.dir='/tmp";
+            var container = AutoFixture.Build<V1Container>()
+                .With(x => x.Env, new List<V1EnvVar> { new("JAVA_TOOL_OPTIONS", existingToolOptions) }).Create();
+
+            // Act
+            patcher.PatchContainer(container, context);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                container.Env.Should()
+                    .Contain(x => x.Name == "CONTRAST_EXISTING_JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+                container.Env.Should()
+                    .Contain(x => x.Name == "JAVA_TOOL_OPTIONS" && x.Value == existingToolOptions);
+            }
+        }
+
     }
 }

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParserTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParserTests.cs
@@ -159,7 +159,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Uti
             var action = () => JavaArgumentParser.ParseArguments(input).ToList();
 
             // Assert
-            action.Should().Throw<Exception>();
+            action.Should().Throw<JavaArgumentParserException>();
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Uti
             var action = () => JavaArgumentParser.ParseArguments(input).ToList();
 
             // Assert
-            action.Should().Throw<Exception>();
+            action.Should().Throw<JavaArgumentParserException>();
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Uti
             var action = () => JavaArgumentParser.ParseArguments(input).ToList();
 
             // Assert
-            action.Should().Throw<Exception>();
+            action.Should().Throw<JavaArgumentParserException>();
         }
 
         [Fact]

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParserTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Utility/JavaArgumentParserTests.cs
@@ -1,0 +1,302 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Utility;
+using FluentAssertions;
+using Xunit;
+
+namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Utility
+{
+    public class JavaArgumentParserTests
+    {
+        [Fact]
+        public void Can_parse_java_example()
+        {
+            const string input = "-g @file1 -Dprop=value -Dws.prop=\"space spaces\" -Dwssq.prop='space spaces' -Xint";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "-g",
+                "@file1",
+                "-Dprop=value",
+                "-Dws.prop=\"space spaces\"",
+                "-Dwssq.prop='space spaces'",
+                "-Xint"
+            });
+        }
+
+
+        [Fact]
+        public void Can_parse_space_separated()
+        {
+            const string input = "test test test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "test",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_quoted_words()
+        {
+            const string input = "test \"test\" test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "\"test\"",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_quoted_words_next_to_words()
+        {
+            const string input = "test\"test\" test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test\"test\"",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_quoted_words_with_spaces()
+        {
+            const string input = "test \"test test\"";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "\"test test\""
+            });
+        }
+
+        [Fact]
+        public void Can_parse_single_quotes()
+        {
+            const string input = "test 'test' test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "'test'",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_single_quote_in_double_quotes()
+        {
+            const string input = "test \"test' test\" test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "\"test' test\"",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_double_quote_in_single_quotes()
+        {
+            const string input = "test 'test\" test' test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "'test\" test'",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Should_throw_unmathced_single_quote()
+        {
+            const string input = "test 'test test";
+
+            // Act
+            var action = () => JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            action.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void Should_throw_unmatched_double_quote()
+        {
+            const string input = "test \"test test";
+
+            // Act
+            var action = () => JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            action.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void Should_throw_following_quotes()
+        {
+            const string input = "test'";
+
+            // Act
+            var action = () => JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            action.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void Can_parse_multiple_whitespaces()
+        {
+            const string input = "test  test test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test",
+                "test",
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_single_word()
+        {
+            const string input = "test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_leading_whitespace()
+        {
+            const string input = " test";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_following_whitespace()
+        {
+            const string input = "test ";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "test"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_final_quotes()
+        {
+            const string input = "'test'";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEquivalentTo(new List<string>
+            {
+                "'test'"
+            });
+        }
+
+        [Fact]
+        public void Can_parse_only_whitespace()
+        {
+            const string input = " ";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input).ToList();
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Can_parse_empty()
+        {
+            const string input = "";
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Can_parse_null()
+        {
+            const string input = null!;
+
+            // Act
+            var result = JavaArgumentParser.ParseArguments(input);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+    }
+}


### PR DESCRIPTION
If a pod already has JAVA_TOOL_OPTIONS set on it, this new logic will parse and patch in our `-javaagent:contrast-agent.jar` argument. This also handles if `contrast-agent.jar` is already present and sets it to the correct path.