### PR TITLE
Allow imagePullSecrets to be added via Helm.

### DIFF
--- a/manifests/helm/build/templates/overlays/deployment.yaml
+++ b/manifests/helm/build/templates/overlays/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      imagePullSecrets:
+        - name: '{{ .Values.imageCredentials.pullSecretName }}'
       containers:
         - name: contrast-agent-operator
           env:

--- a/manifests/helm/templates/image-pull-secrets.yaml.tpl
+++ b/manifests/helm/templates/image-pull-secrets.yaml.tpl
@@ -1,0 +1,16 @@
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}
+{{ if .Values.imageCredentials.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imageCredentials.pullSecretName }}
+  namespace: >-
+    {{ .Values.namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{ end }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -6,6 +6,16 @@ image:
   # Defaults to the version specified in Chart.AppVersion.
   tag:
 
+imageCredentials:
+  # Name of the registry credential secret that should be used to pull the above image.
+  pullSecretName: image-credentials
+  # If enabled, a registry credential secret will be created using the above name and below credentials.
+  enabled: false
+  registry: contrast
+  username:
+  password:
+  email:
+
 operator:
   # The default registry to use, defaults to docker.io/contrast.
   defaultRegistry: contrast


### PR DESCRIPTION
Allow configuration of a named secret which will be included in the `imagePullSecrets` spec for the operator image.
Configuration allows for the optional creation of the `dockerconfigjson` secret with provided credentials.

Have tested with:
1. No named secret defined - works for public repo, fails as expected for private `ghcr.io` repository
2. `imageCredentials.enabled=true` and a set of credentials to pull an image from private `ghcr.io` repository
3. `imageCredentials.enabled=false` and a manually created secret in the `contrast-agent-operator` namespace to pull an image from private `ghcr.io` repository