### PR TITLE
Build but don't push the docker image for PR builds

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,6 +69,7 @@ jobs:
           tags: |
             type=raw,value=trunk-artifact,enable=${{ github.ref == 'refs/heads/master' }}
             type=raw,value=pr-artifact,enable=${{ github.event_name == 'pull_request' }}
+            type=raw,value=dispatch-artifact,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=release-artifact,enable=${{ needs.generate-version.outputs.version != '0.0.1' }}
       - uses: docker/build-push-action@v4
         id: build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           file: Dockerfile
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }} # don't push the image for PR builds
           cache-from: ${{ github.actor != 'dependabot[bot]' && format('type=registry,ref={0}:cache', env.IMAGE_NAME) || ''}}
           cache-to: ${{ github.actor != 'dependabot[bot]' && format('type=registry,ref={0}:cache,mode=max', env.IMAGE_NAME) || ''}}
           build-args: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -179,6 +179,7 @@ jobs:
       fail-fast: false
     env:
       IMAGE: ghcr.io/contrast-security-oss/agent-operator/operator@${{ needs.build-image.outputs.digest }}
+    if: ${{ github.event_name != 'pull_request' }} # should match push logic in build-image
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This fixes the issue of PR builds failing due to not having write permissions to the repo.

The image push and k3s image test step can be manually triggered by workflow_dispatch.