### PR TITLE
Update PodPatcher.cs Adding automatic session_metadata based on the image version of the running pod

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
@@ -109,7 +109,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching
                 var writableVolumeMount = new V1VolumeMount(context.WritableMountPath, writableVolume.Name, readOnlyProperty: false);
                 container.VolumeMounts.AddOrUpdate(writableVolumeMount.Name, writableVolumeMount);
 
-                var genericPatches = GenerateEnvVars(context);
+                var genericPatches = GenerateEnvVars(context,pod);
                 var agentPatches = agentPatcher?.GenerateEnvVars(context) ?? Array.Empty<V1EnvVar>();
 
                 foreach (var envVar in genericPatches.Concat(agentPatches))
@@ -254,7 +254,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching
             }
         }
 
-        private IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context)
+        private IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context,V1Pod pod)
         {
             var (workloadName, workloadNamespace, _, connection, configuration, agentMountPath, writableMountPath) = context;
 
@@ -262,7 +262,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching
             yield return new V1EnvVar("CONTRAST_MOUNT_PATH", agentMountPath);
             yield return new V1EnvVar("CONTRAST_MOUNT_AGENT_PATH", agentMountPath);
             yield return new V1EnvVar("CONTRAST_MOUNT_WRITABLE_PATH", writableMountPath);
-
+            yield return new V1EnvVar("CONTRAST__APPLICATION__SESSION_METADATA", $"imageVersion={pod.Spec.Containers[0].Image}");
             yield return new V1EnvVar("CONTRAST__API__URL", connection.TeamServerUri);
             yield return new V1EnvVar(
                 "CONTRAST__API__API_KEY",


### PR DESCRIPTION
Adding automatic session_metadata based on the image version of the running PoD

IMAGEVERSION will appear automatically in the vulnerability view