### PR TITLE
Adding Argo rollout support

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Controllers/RolloutController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/RolloutController.cs
@@ -8,19 +8,14 @@ using JetBrains.Annotations;
 using k8s.Models;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Rbac;
-using NLog;
 
 namespace Contrast.K8s.AgentOperator.Controllers
 {
     //[EntityRbac(typeof(V1alpha1Rollout), Verbs = VerbConstants.ReadAndPatch), UsedImplicitly]
     public class RolloutController : GenericController<V1alpha1Rollout> //IResourceController<V1alpha1Rollout>
     {
-        //private readonly IEventStream _eventStream;
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         public RolloutController(IEventStream eventStream) : base(eventStream)
         {
-            //_eventStream = eventStream;
-            Logger.Info($"RolloutController {eventStream.ToString()}");
         }
     }
 }

--- a/src/Contrast.K8s.AgentOperator/Controllers/RolloutController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/RolloutController.cs
@@ -1,0 +1,26 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Contrast.K8s.AgentOperator.Core.Kube;
+using Contrast.K8s.AgentOperator.Core.State;
+using Contrast.K8s.AgentOperator.Entities;
+using JetBrains.Annotations;
+using k8s.Models;
+using KubeOps.Operator.Controller;
+using KubeOps.Operator.Rbac;
+using NLog;
+
+namespace Contrast.K8s.AgentOperator.Controllers
+{
+    //[EntityRbac(typeof(V1alpha1Rollout), Verbs = VerbConstants.ReadAndPatch), UsedImplicitly]
+    public class RolloutController : GenericController<V1alpha1Rollout> //IResourceController<V1alpha1Rollout>
+    {
+        //private readonly IEventStream _eventStream;
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        public RolloutController(IEventStream eventStream) : base(eventStream)
+        {
+            //_eventStream = eventStream;
+            Logger.Info($"RolloutController {eventStream.ToString()}");
+        }
+    }
+}

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
@@ -11,7 +11,7 @@ using Contrast.K8s.AgentOperator.Core.State;
 using Contrast.K8s.AgentOperator.Core.State.Resources;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Interfaces;
 using Contrast.K8s.AgentOperator.Entities.OpenShift;
-using Contrast.K8s.AgentOperator.Entities.V1alpha1Rollout;
+using Contrast.K8s.AgentOperator.Entities;
 using JetBrains.Annotations;
 using k8s.Models;
 using MediatR;

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
@@ -11,6 +11,7 @@ using Contrast.K8s.AgentOperator.Core.State;
 using Contrast.K8s.AgentOperator.Core.State.Resources;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Interfaces;
 using Contrast.K8s.AgentOperator.Entities.OpenShift;
+using Contrast.K8s.AgentOperator.Entities.V1alpha1Rollout;
 using JetBrains.Annotations;
 using k8s.Models;
 using MediatR;
@@ -84,6 +85,7 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting
             {
                 DaemonSetResource => PatchToDesiredStateDaemonSet(desiredState, identity),
                 StatefulSetResource => PatchToDesiredStateStatefulSet(desiredState, identity),
+                RolloutResource => PatchToDesiredStateRollout(desiredState, identity),
                 DeploymentResource => PatchToDesiredStateDeployment(desiredState, identity),
                 DeploymentConfigResource => PatchToDesiredStateDeploymentConfig(desiredState, identity),
                 _ => throw new ArgumentOutOfRangeException()
@@ -107,7 +109,11 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting
             await _state.MarkAsDirty(identity);
             await _patcher.Patch<V1Deployment>(identity.Name, identity.Namespace, o => { PatchAnnotations(desiredState, o.Spec.Template); });
         }
-
+        private async ValueTask PatchToDesiredStateRollout(DesiredState desiredState, NamespacedResourceIdentity identity)
+        {
+            await _state.MarkAsDirty(identity);
+            await _patcher.Patch<V1alpha1Rollout>(identity.Name, identity.Namespace, o => { PatchAnnotations(desiredState, o.Spec.Template); });
+        }
         private async ValueTask PatchToDesiredStateDeploymentConfig(DesiredState desiredState, NamespacedResourceIdentity identity)
         {
             await _state.MarkAsDirty(identity);

--- a/src/Contrast.K8s.AgentOperator/Core/State/Appliers/RolloutApplier.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/State/Appliers/RolloutApplier.cs
@@ -1,0 +1,34 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Contrast.K8s.AgentOperator.Core.Kube;
+using Contrast.K8s.AgentOperator.Core.State.Resources;
+using Contrast.K8s.AgentOperator.Entities;
+using JetBrains.Annotations;
+using k8s.Models;
+using MediatR;
+
+namespace Contrast.K8s.AgentOperator.Core.State.Appliers
+{
+    [UsedImplicitly]
+    public class RolloutApplier : BaseApplier<V1alpha1Rollout, RolloutResource>
+    {
+        public RolloutApplier(IStateContainer stateContainer, IMediator mediator) : base(stateContainer, mediator)
+        {
+        }
+
+        public override ValueTask<RolloutResource> CreateFrom(V1alpha1Rollout entity, CancellationToken cancellationToken = default)
+        {
+            var resource = new RolloutResource(
+                entity.Uid(),
+                entity.  Metadata.GetLabels(),
+                entity.Spec.Template.GetPod(),
+                entity.Spec.Selector.ToPodSelector()
+            );
+
+            return ValueTask.FromResult(resource);
+        }
+    }
+}

--- a/src/Contrast.K8s.AgentOperator/Core/State/Resources/RolloutResource.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/State/Resources/RolloutResource.cs
@@ -1,0 +1,20 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Contrast.K8s.AgentOperator.Core.State.Resources.Interfaces;
+using Contrast.K8s.AgentOperator.Core.State.Resources.Primitives;
+
+
+namespace Contrast.K8s.AgentOperator.Core.State.Resources
+{
+
+        public record RolloutResource(string Uid,
+                                 IReadOnlyCollection<MetadataLabel> Labels,
+                                 PodTemplate PodTemplate,
+                                 PodSelector Selector)
+    : IResourceWithPodTemplate;
+    
+}
+
+

--- a/src/Contrast.K8s.AgentOperator/Entities/V1Alpha1ArgoRollout.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/V1Alpha1ArgoRollout.cs
@@ -1,0 +1,30 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s.Models;
+using k8s;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using KubeOps.Operator.Entities.Annotations;
+using KubeOps.Operator.Entities;
+using Contrast.K8s.AgentOperator.Core.Kube;
+using JetBrains.Annotations;
+using KubeOps.Operator.Rbac;
+
+namespace Contrast.K8s.AgentOperator.Entities
+{
+
+
+
+    [IgnoreEntity]
+    [EntityRbac(typeof(V1alpha1Rollout), Verbs = VerbConstants.ReadAndPatch), UsedImplicitly]
+    [KubernetesEntity(Group = "argoproj.io", ApiVersion = "v1alpha1", Kind = "Rollout", PluralName = "rollouts")]
+    public class V1alpha1Rollout : CustomKubernetesEntity<V1alpha1Rollout.V1alpha1rolloutSpec>
+    {
+        public class V1alpha1rolloutSpec : V1DeploymentSpec
+        {
+            //public string Host { get; set; }
+        }
+    }
+
+}


### PR DESCRIPTION
this requires to generate a new install_prod.yaml (propably done autiomatically in your pipeline ?) that includes rbac rules for argo rollouts.