### PR TITLE
Support creating AgentInjectors in the chart

### DIFF
--- a/manifests/helm/templates/agent-injectors.yaml.tpl
+++ b/manifests/helm/templates/agent-injectors.yaml.tpl
@@ -1,0 +1,45 @@
+{{ if .Values.agentInjectors.enabled }}
+{{- range $injector := .Values.agentInjectors.injectors }}
+{{- range $namespace := .namespaces }}
+---
+apiVersion: agents.contrastsecurity.com/v1beta1
+kind: AgentInjector
+metadata:
+  name: {{ $injector.name }}
+  namespace: {{ $namespace }}
+spec:
+  {{- if eq $injector.enabled false}}
+  enabled: false
+  {{- end }}
+  {{- if $injector.connectionName }}
+  connection:
+    name: {{ $injector.connectionName }}
+  {{- end}}
+  {{- if $injector.configurationName }}
+  configuration:
+    name: {{ $injector.configurationName }}
+  {{- end }}
+  {{- if $injector.imageVersion }}
+  version: {{ quote $injector.imageVersion }}
+  {{- end }}
+  type: {{ $injector.language }}
+  {{- if $injector.image }}
+  image:
+    {{- $injector.image | toYaml | nindent 4 }}
+  {{- end}}
+  {{ $selector := $injector.selector | default dict -}}
+  {{- $labels := $selector.labels -}}
+  {{- $images := $selector.images -}}
+  {{- $_ := required "One of injector.selector.labels or injector.selector.images required" (coalesce $labels $images) -}}
+  selector:
+  {{- if $labels }}
+    labels:
+      {{- $labels | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if $images }}
+    images:
+      {{- $images | toYaml | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/manifests/helm/templates/agent-injectors.yaml.tpl
+++ b/manifests/helm/templates/agent-injectors.yaml.tpl
@@ -27,18 +27,17 @@ spec:
   image:
     {{- $injector.image | toYaml | nindent 4 }}
   {{- end}}
+  {{- if or $injector.selector $injector.images }}
   {{ $selector := $injector.selector | default dict -}}
-  {{- $labels := $selector.labels -}}
-  {{- $images := $selector.images -}}
-  {{- $_ := required "One of injector.selector.labels or injector.selector.images required" (coalesce $labels $images) -}}
   selector:
-  {{- if $labels }}
+  {{- if $selector.labels }}
     labels:
-      {{- $labels | toYaml | nindent 6 }}
+      {{- $selector.labels | toYaml | nindent 6 }}
   {{- end }}
-  {{- if $images }}
+  {{- if $selector.images }}
     images:
-      {{- $images | toYaml | nindent 6 }}
+      {{- $selector.images | toYaml | nindent 6 }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/helm/values.testing.yaml
+++ b/manifests/helm/values.testing.yaml
@@ -7,3 +7,16 @@ clusterDefaults:
   yaml: |-
     enable: true
     second-line: something
+
+agentInjectors:
+  enabled: true
+  injectors:
+    - language: java
+      name: helm-java-injector
+      namespaces:
+        - test1
+        - test2
+      selector:
+        labels:
+          - name: contrast-agent
+            value: java

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -65,13 +65,17 @@ agentInjectors:
       name: contrast-java-injector
       # Optional, defaults to true (enabled)
       enabled: true
-      #Required. This injector will be created in each specified namespace.
+      # Required. This injector will be created in each specified namespace.
       namespaces:
         - default
+      # Optional, specify labels and/or image names to inject. If omitted, all workloads will be injected.
+      # Label selections are cumulative using the logical AND operation.
       selector:
         labels:
           - name: contrast-agent
             value: java
+        #images:
+        #  - imagename
       # Optional image configuration.
       # image:
       #   registry: docker.io/contrast

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -57,3 +57,54 @@ clusterDefaults:
   # Optional. Any custom configuration to use. Must be in the format of the standard YAML file.
   yaml: |-
     enable: true
+
+agentInjectors:
+  enabled: true
+  injectors:
+    - language: java
+      name: contrast-java-injector
+      # Optional, defaults to true (enabled)
+      enabled: true
+      #Required. This injector will be created in each specified namespace.
+      namespaces:
+        - default
+      selector:
+        labels:
+          - name: contrast-agent
+            value: java
+      # Optional image configuration.
+      # image:
+      #   registry: docker.io/contrast
+      #   name: agent-java
+      #   pullPolicy: Always
+      # Optional image version, defaults to latest
+      #imageVersion: 5
+      # Optional name of an AgentConfiguration to use with this injector
+      #configurationName: custom-config-name
+      # Optional name of an AgentConnection to use with this injector
+      #connectionName: custom-connection-name
+
+    - language: dotnet-core
+      name: contrast-dotnet-core-injector
+      namespaces:
+        - default
+      selector:
+        labels:
+          - name: contrast-agent
+            value: dotnet-core
+    - language: nodejs
+      name: contrast-nodejs-injector
+      namespaces:
+        - default
+      selector:
+        labels:
+          - name: contrast-agent
+            value: nodejs
+    - language: php
+      name: contrast-php-injector
+      namespaces:
+        - default
+      selector:
+        labels:
+          - name: contrast-agent
+            value: php


### PR DESCRIPTION
Adding support for the chart to create `AgentInjector`s.

As it is common for a cluster to contain several namespaces, and multiple languages are supported by the operator, this takes in an array of injectors, where each injector can specify a number of namespaces.
Each configured injector will be emitted for each specified namespace.

values.yaml includes an example of the full available injector configuration, plus minimal config for the other languages. Examples use a reasonable default selector of `contrast-agent=<language-to-inject>`.