### PR TITLE
DOTNET-5476 Deprecate nodejs-protect agent injector

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/IAgentPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/IAgentPatcher.cs
@@ -9,6 +9,8 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
 {
     public interface IAgentPatcher
     {
+        bool Deprecated => false;
+
         AgentInjectionType Type { get; }
 
         IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context);

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/NodeJsProtectAgentPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/NodeJsProtectAgentPatcher.cs
@@ -9,6 +9,9 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching.Agents
 {
     public class NodeJsProtectAgentPatcher : IAgentPatcher
     {
+        //This patcher is deprecated as of nodejs agent v5
+        public bool Deprecated => true;
+
         public AgentInjectionType Type => AgentInjectionType.NodeJsProtect;
 
         public IEnumerable<V1EnvVar> GenerateEnvVars(PatchingContext context)

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
@@ -41,6 +41,11 @@ namespace Contrast.K8s.AgentOperator.Core.Reactions.Injecting.Patching
             var patchers = _patchersFactory.Invoke();
             var patcher = patchers.FirstOrDefault(x => x.Type == context.Injector.Type);
 
+            if (patcher is { Deprecated: true })
+            {
+                Logger.Warn($"Using deprecated agent injector '{patcher?.Type.ToString() ?? "Default"}'.");
+            }
+
             if (patcher?.GetOverrideAgentMountPath() is { } agentMountPathOverride)
             {
                 context = context with

--- a/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentInjector.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentInjector.cs
@@ -31,7 +31,7 @@ namespace Contrast.K8s.AgentOperator.Entities
             public string? Version { get; set; }
 
             /// <summary>
-            /// The type of agent to inject. Can be one of ['dotnet-core', 'java', 'nodejs', 'nodejs-protect', 'php'].
+            /// The type of agent to inject. Can be one of ['dotnet-core', 'java', 'nodejs', 'php'].
             /// Required.
             /// </summary>
             [Required, Pattern(RegexConstants.AgentTypeRegex)]


### PR DESCRIPTION
With the release of the nodejs v5 agent, the nodejs-protect agent is being deprecated.
This adds support for deprecating an agent patcher and logging a warning if it is used.