### PR TITLE
Upgrade to v4 of upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -115,7 +115,7 @@ jobs:
           cp manifests/install/prod-quay/install-prod-quay.yaml ./install-prod-quay.yaml
         shell: bash
       - name: Publish (Artifacts)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: manifests
           path: |
@@ -151,14 +151,14 @@ jobs:
             | tee ./manifests/helm/dist/output.yaml
         shell: bash
       - name: Publish (Chart)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: helm-chart
           path: |
             manifests/helm/dist/*.tgz
           retention-days: 7
       - name: Publish (Manifests)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: helm-manifests
           path: |
@@ -270,7 +270,7 @@ jobs:
           tar xf kubeconform-linux-amd64.tar.gz
           sudo install kubeconform /usr/local/bin/kubeconform
       - name: Download Manifests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download-artifacts
         with:
           name: ${{ matrix.artifact }}
@@ -408,7 +408,7 @@ jobs:
           dst: |
             ${{ steps.dockerhub-meta.outputs.tags }}
             ${{ steps.quay-meta.outputs.tags }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download-artifacts
         with:
           name: manifests


### PR DESCRIPTION
Dependabot PR's fail because they need to be matched versions