### PR TITLE
Make injector namespace a top-level config property

### DIFF
--- a/manifests/helm/templates/agent-injectors.yaml.tpl
+++ b/manifests/helm/templates/agent-injectors.yaml.tpl
@@ -1,6 +1,6 @@
 {{ if .Values.agentInjectors.enabled }}
-{{- range $injector := .Values.agentInjectors.injectors }}
-{{- range $namespace := .namespaces }}
+{{- range $namespace := .Values.agentInjectors.namespaces }}
+{{- range $injector := $.Values.agentInjectors.injectors }}
 ---
 apiVersion: agents.contrastsecurity.com/v1beta1
 kind: AgentInjector

--- a/manifests/helm/values.testing.yaml
+++ b/manifests/helm/values.testing.yaml
@@ -10,12 +10,12 @@ clusterDefaults:
 
 agentInjectors:
   enabled: true
+  namespaces:
+    - test1
+    - test2
   injectors:
     - language: java
       name: helm-java-injector
-      namespaces:
-        - test1
-        - test2
       selector:
         labels:
           - name: contrast-agent

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -60,14 +60,14 @@ clusterDefaults:
 
 agentInjectors:
   enabled: true
+  # Required. All injectors will be created in each specified namespace.
+  namespaces:
+    - default
   injectors:
     - language: java
       name: contrast-java-injector
       # Optional, defaults to true (enabled)
       enabled: true
-      # Required. This injector will be created in each specified namespace.
-      namespaces:
-        - default
       # Optional, specify labels and/or image names to inject. If omitted, all workloads will be injected.
       # Label selections are cumulative using the logical AND operation.
       selector:
@@ -90,24 +90,18 @@ agentInjectors:
 
     - language: dotnet-core
       name: contrast-dotnet-core-injector
-      namespaces:
-        - default
       selector:
         labels:
           - name: contrast-agent
             value: dotnet-core
     - language: nodejs
       name: contrast-nodejs-injector
-      namespaces:
-        - default
       selector:
         labels:
           - name: contrast-agent
             value: nodejs
     - language: php
       name: contrast-php-injector
-      namespaces:
-        - default
       selector:
         labels:
           - name: contrast-agent


### PR DESCRIPTION
Make `agentInjectors.namespaces` a top level config property so you can define it once rather than on every Injector.