### PR TITLE
Allow configuration of the initContainer resources

### DIFF
--- a/manifests/helm/build/templates/overlays/deployment.yaml
+++ b/manifests/helm/build/templates/overlays/deployment.yaml
@@ -27,3 +27,11 @@ spec:
               value: '{{ .Values.operator.enableEarlyChaining }}'
             - name: CONTRAST_INSTALL_SOURCE
               value: helm
+            - name: CONTRAST_INITCONTAINER_CPU_REQUEST
+              value: '{{ .Values.operator.initContainer.resources.requests.cpu }}'
+            - name: CONTRAST_INITCONTAINER_CPU_LIMIT
+              value: '{{ .Values.operator.initContainer.resources.limits.cpu }}'
+            - name: CONTRAST_INITCONTAINER_MEMORY_REQUEST
+              value: '{{ .Values.operator.initContainer.resources.requests.memory }}'
+            - name: CONTRAST_INITCONTAINER_MEMORY_LIMIT
+              value: '{{ .Values.operator.initContainer.resources.limits.memory }}'

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -42,6 +42,15 @@ operator:
   webhookConfiguration: contrast-web-hook-configuration
   # Enable early chaining. Should normally be disabled unless DynaKube is used in classicStack mode.
   enableEarlyChaining: false
+  # Resource management for the agent initContainers
+  initContainer:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 64Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
 
 clusterDefaults:
   # If enabled, configure cluster-wide defaults.

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
@@ -186,18 +186,16 @@ public class PodPatcher : IPodPatcher
         securityContent.Capabilities.Drop ??= MergeDropCapabilities(containerSecurityContext);
 
         // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-        var (cpuRequest, memoryRequest) = _operatorOptions.initRequests;
-        var (cpuLimit, memoryLimit) = _operatorOptions.initLimits;
-
+        var initOptions = _operatorOptions.InitContainerOptions;
         var resources = new V1ResourceRequirements();
 
         resources.Requests ??= new Dictionary<string, ResourceQuantity>(StringComparer.Ordinal);
-        resources.Requests.TryAdd("cpu", new ResourceQuantity(cpuRequest));
-        resources.Requests.TryAdd("memory", new ResourceQuantity(memoryRequest));
+        resources.Requests.TryAdd("cpu", new ResourceQuantity(initOptions.CpuRequest));
+        resources.Requests.TryAdd("memory", new ResourceQuantity(initOptions.MemoryRequest));
 
         resources.Limits ??= new Dictionary<string, ResourceQuantity>(StringComparer.Ordinal);
-        resources.Limits.TryAdd("cpu", new ResourceQuantity(cpuLimit));
-        resources.Limits.TryAdd("memory", new ResourceQuantity(memoryLimit));
+        resources.Limits.TryAdd("cpu", new ResourceQuantity(initOptions.CpuLimit));
+        resources.Limits.TryAdd("memory", new ResourceQuantity(initOptions.MemoryLimit));
 
         var initContainer = new V1Container("contrast-init")
         {

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
@@ -186,14 +186,14 @@ public class PodPatcher : IPodPatcher
         securityContent.Capabilities.Drop ??= MergeDropCapabilities(containerSecurityContext);
 
         // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
-        const string cpuLimit = "100m";
-        const string memoryLimit = "64Mi";
+        var (cpuRequest, memoryRequest) = _operatorOptions.initRequests;
+        var (cpuLimit, memoryLimit) = _operatorOptions.initLimits;
 
         var resources = new V1ResourceRequirements();
 
         resources.Requests ??= new Dictionary<string, ResourceQuantity>(StringComparer.Ordinal);
-        resources.Requests.TryAdd("cpu", new ResourceQuantity(cpuLimit));
-        resources.Requests.TryAdd("memory", new ResourceQuantity(memoryLimit));
+        resources.Requests.TryAdd("cpu", new ResourceQuantity(cpuRequest));
+        resources.Requests.TryAdd("memory", new ResourceQuantity(memoryRequest));
 
         resources.Limits ??= new Dictionary<string, ResourceQuantity>(StringComparer.Ordinal);
         resources.Limits.TryAdd("cpu", new ResourceQuantity(cpuLimit));

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -91,32 +91,32 @@ public class OptionsModule : Module
                 chaosPercent = parsedChaosPercent;
             }
 
-            var @cpuRequest = "100m";
-            var @cpuLimit = "100m";
+            var cpuRequest = "100m";
+            var cpuLimit = "100m";
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_CPU_REQUEST", out var cpuRequestStr))
             {
-                logger.LogOptionValue("initcontainer-cpu-request", @cpuRequest, cpuRequestStr);
-                @cpuRequest = cpuRequestStr;
+                logger.LogOptionValue("initcontainer-cpu-request", cpuRequest, cpuRequestStr);
+                cpuRequest = cpuRequestStr;
             }
 
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_CPU_LIMIT", out var cpuLimitStr))
             {
-                logger.LogOptionValue("initcontainer-cpu-limit", @cpuLimit, cpuLimitStr);
-                @cpuLimit = cpuLimitStr;
+                logger.LogOptionValue("initcontainer-cpu-limit", cpuLimit, cpuLimitStr);
+                cpuLimit = cpuLimitStr;
             }
 
-            var @memoryLimit = "64Mi";
-            var @memoryRequest = "64Mi";
+            var memoryLimit = "64Mi";
+            var memoryRequest = "64Mi";
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_MEMORY_REQUEST", out var memoryRequestStr))
             {
-                logger.LogOptionValue("initcontainer-memory-request", @memoryRequest, memoryRequestStr);
-                @memoryRequest = memoryRequestStr;
+                logger.LogOptionValue("initcontainer-memory-request", memoryRequest, memoryRequestStr);
+                memoryRequest = memoryRequestStr;
             }
 
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_MEMORY_LIMIT", out var memoryLimitStr))
             {
-                logger.LogOptionValue("initcontainer-memory-limit", @memoryLimit, memoryLimitStr);
-                @memoryLimit = memoryLimitStr;
+                logger.LogOptionValue("initcontainer-memory-limit", memoryLimit, memoryLimitStr);
+                memoryLimit = memoryLimitStr;
             }
 
             return new OperatorOptions(
@@ -128,8 +128,7 @@ public class OptionsModule : Module
                 runInitContainersAsNonRoot,
                 suppressSeccompProfile,
                 chaosPercent / 100m,
-                (cpuRequest, memoryRequest),
-                (cpuLimit, memoryLimit)
+                new InitContainerOptions(cpuRequest, cpuLimit, memoryRequest, memoryLimit)
             );
         }).SingleInstance();
 

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -91,6 +91,34 @@ public class OptionsModule : Module
                 chaosPercent = parsedChaosPercent;
             }
 
+            var @cpuRequest = "100m";
+            var @cpuLimit = "100m";
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_CPU_REQUEST", out var cpuRequestStr))
+            {
+                logger.LogOptionValue("initcontainer-cpu-request", @cpuRequest, cpuRequestStr);
+                @cpuRequest = cpuRequestStr;
+            }
+
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_CPU_LIMIT", out var cpuLimitStr))
+            {
+                logger.LogOptionValue("initcontainer-cpu-limit", @cpuLimit, cpuLimitStr);
+                @cpuLimit = cpuLimitStr;
+            }
+
+            var @memoryLimit = "64Mi";
+            var @memoryRequest = "64Mi";
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_MEMORY_REQUEST", out var memoryRequestStr))
+            {
+                logger.LogOptionValue("initcontainer-memory-request", @memoryRequest, memoryRequestStr);
+                @memoryRequest = memoryRequestStr;
+            }
+
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_MEMORY_LIMIT", out var memoryLimitStr))
+            {
+                logger.LogOptionValue("initcontainer-memory-limit", @memoryLimit, memoryLimitStr);
+                @memoryLimit = memoryLimitStr;
+            }
+
             return new OperatorOptions(
                 @namespace,
                 settleDuration,
@@ -99,7 +127,9 @@ public class OptionsModule : Module
                 eventQueueMergeWindowSeconds,
                 runInitContainersAsNonRoot,
                 suppressSeccompProfile,
-                chaosPercent / 100m
+                chaosPercent / 100m,
+                (cpuRequest, memoryRequest),
+                (cpuLimit, memoryLimit)
             );
         }).SingleInstance();
 

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -91,6 +91,21 @@ public class OptionsModule : Module
                 chaosPercent = parsedChaosPercent;
             }
 
+            return new OperatorOptions(
+                @namespace,
+                settleDuration,
+                eventQueueSize,
+                fullMode,
+                eventQueueMergeWindowSeconds,
+                runInitContainersAsNonRoot,
+                suppressSeccompProfile,
+                chaosPercent / 100m);
+        }).SingleInstance();
+
+        builder.Register(context =>
+        {
+            var logger = context.Resolve<IOptionsLogger>();
+
             var cpuRequest = "100m";
             var cpuLimit = "100m";
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_CPU_REQUEST", out var cpuRequestStr))
@@ -119,17 +134,7 @@ public class OptionsModule : Module
                 memoryLimit = memoryLimitStr;
             }
 
-            return new OperatorOptions(
-                @namespace,
-                settleDuration,
-                eventQueueSize,
-                fullMode,
-                eventQueueMergeWindowSeconds,
-                runInitContainersAsNonRoot,
-                suppressSeccompProfile,
-                chaosPercent / 100m,
-                new InitContainerOptions(cpuRequest, cpuLimit, memoryRequest, memoryLimit)
-            );
+            return new InitContainerOptions(cpuRequest, cpuLimit, memoryRequest, memoryLimit);
         }).SingleInstance();
 
         builder.Register(context =>

--- a/src/Contrast.K8s.AgentOperator/Options/InitContainerOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/InitContainerOptions.cs
@@ -1,0 +1,10 @@
+﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Contrast.K8s.AgentOperator.Options;
+
+public record InitContainerOptions(
+    string CpuRequest,
+    string CpuLimit,
+    string MemoryRequest,
+    string MemoryLimit);

--- a/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
@@ -13,5 +13,4 @@ public record OperatorOptions(string Namespace,
                               bool RunInitContainersAsNonRoot,
                               bool SuppressSeccompProfile,
                               decimal ChaosRatio,
-                              InitContainerOptions InitContainerOptions,
                               string FieldManagerName = "agents.contrastsecurity.com");

--- a/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
@@ -13,4 +13,6 @@ public record OperatorOptions(string Namespace,
                               bool RunInitContainersAsNonRoot,
                               bool SuppressSeccompProfile,
                               decimal ChaosRatio,
+                              (string cpuRequest, string memoryRequest) initRequests,
+                              (string cpuLimit, string memoryLimit) initLimits,
                               string FieldManagerName = "agents.contrastsecurity.com");

--- a/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/OperatorOptions.cs
@@ -13,6 +13,5 @@ public record OperatorOptions(string Namespace,
                               bool RunInitContainersAsNonRoot,
                               bool SuppressSeccompProfile,
                               decimal ChaosRatio,
-                              (string cpuRequest, string memoryRequest) initRequests,
-                              (string cpuLimit, string memoryLimit) initLimits,
+                              InitContainerOptions InitContainerOptions,
                               string FieldManagerName = "agents.contrastsecurity.com");


### PR DESCRIPTION
Allows configuration of the initContainer request and limit fields for both memory and CPU, sourced from environment variables on the operator.
Defaults remain the same as they have always been set.
Support added to the helm chart to set these variables.