### PR TITLE
📝 Add helm notes with post-install information

### DIFF
--- a/manifests/helm/templates/NOTES.txt
+++ b/manifests/helm/templates/NOTES.txt
@@ -1,0 +1,41 @@
+{{ .Chart.Name }} version {{ .Chart.Version }} deployed!
+
+{{- if .Values.agentInjectors.enabled }}
+✅ {{ len .Values.agentInjectors.injectors }} {{ len .Values.agentInjectors.injectors | plural "injector" "injectors" }} {{ len .Values.agentInjectors.injectors | plural "has" "have" }} been deployed to {{ len .Values.agentInjectors.namespaces | plural "namespace" "namespaces" }}: {{ join ", " .Values.agentInjectors.namespaces}}
+  To use with your workloads:
+
+  {{- range $injector := $.Values.agentInjectors.injectors }}
+
+  {{ $injector.name }} ({{ $injector.language }}{{- if $injector.imageVersion }}/v{{$injector.imageVersion}}{{- end }}):
+    {{- if or $injector.selector $injector.images }}
+    {{ $selector := $injector.selector | default dict -}}
+    {{- if $selector.labels }}⎈ kubectl label deployment/<your_deployment_name> {{- range $index, $label := $selector.labels }} {{ $label.name }}={{ $label.value }}{{- end -}}
+    {{- else -}}
+    ℹ️  No label requirement
+    {{- end }}
+    {{- if $selector.images }}
+    ℹ️  Applicable only for images named {{ join "|" $selector.images }}
+    {{- end }}
+    {{- else }}
+    🪄  Applies to all workloads
+    {{- end }}
+    {{- if eq $injector.enabled false }}
+    ⚠️  Injector is disabled
+    {{- end }}
+  {{- end }}
+{{- else}}
+⚠️  agentInjectors.enabled was false, so no injectors deployed. Enable this for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentinjector
+{{- end }}
+
+{{ if .Values.clusterDefaults.enabled }}
+✅ Cluster agent defaults deployed
+{{- else }}
+⚠️  clusterDefaults.enabled was false, so no agent connections deployed. Enable this and provide agent credentials for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#clusteragentconnection or https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentconnection
+{{- end }}
+
+👀 To watch the operator logs:
+    ⎈ kubectl logs -f -l app.kubernetes.io/part-of=contrast-agent-operator --namespace {{ .Values.namespace }}
+
+📄 More documentation: https://docs.contrastsecurity.com/en/agent-operator.html
+
+🙋 Get support: https://support.contrastsecurity.com / support@contrastsecurity.com


### PR DESCRIPTION
Adds a Helm NOTES.txt file to provide useful information after the chart is deployed.
Example output:

```
contrast-agent-operator version 1.4.0 deployed!
✅ 7 injectors have been deployed to namespace: default
  To use with your workloads:

  contrast-java-injector (java):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=java

  example-contrast-java-pinned-version-injector (java/v5):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=java contrast-version=5

  contrast-dotnet-core-injector (dotnet-core):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=dotnet-core

  contrast-nodejs-injector (nodejs):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=nodejs

  contrast-nodejs-esm-injector (nodejs-esm):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=nodejs-esm

  contrast-php-injector (php):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=php

  contrast-python-injector (python):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=python


✅ Cluster agent defaults deployed

👀 To watch the operator logs: 
    ⎈ kubectl logs -f -l app.kubernetes.io/part-of=contrast-agent-operator --namespace contrast-agent-operator

📄 More documentation: https://docs.contrastsecurity.com/en/agent-operator.html

🙋 Get support: https://support.contrastsecurity.com / support@contrastsecurity.com
```

Injector for all workloads, in multiple namespaces:
```
contrast-agent-operator version 1.4.0 deployed!
✅ 1 injector has been deployed to namespaces: default, webgoat
  To use with your workloads:

  contrast-java-injector (java):
    🪄  Applies to all workloads
```

Injector requires labels and specific images:
```
✅ 1 injector has been deployed to namespaces: default, webgoat
  To use with your workloads:

  contrast-java-injector (java):
    ⎈ kubectl label deployment/<your_deployment_name> contrast-agent=java
    ℹ️  Applicable only for images named imagename
```

When injectors require no labels, but support only certain images
```
✅ 1 injector has been deployed to namespaces: default, webgoat
  To use with your workloads:

  contrast-java-injector (java):
    ℹ️  No label requirement
    ℹ️  Applicable only for images named myimagename|javaapp
```


Warning/guidance when cluster defaults are not enabled:

```
⚠️  clusterDefaults.enabled was false, so no agent connections deployed. Enable this and provide agent credentials for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#clusteragentconnection or https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentconnection
```

Warning/guidance when agent injectors are not enabled:
```
⚠️ agentInjectors.enabled was false, so no injectors deployed. Enable this for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentinjector
```