### PR TITLE
⌥ Make operator deployment optional in the helm chart

### DIFF
--- a/manifests/helm/build.ps1
+++ b/manifests/helm/build.ps1
@@ -7,7 +7,7 @@ param(
 
 function Invoke-Kustomize([string] $BasePath, [string] $OutputFilePath)
 {
-    kubectl kustomize ([System.IO.Path]::GetFullPath($BasePath)) | Out-File -FilePath $OutputFilePath
+    kubectl kustomize ([System.IO.Path]::GetFullPath($BasePath)) | Out-File -Append -FilePath $OutputFilePath
 }
 
 $root = $PSScriptRoot
@@ -15,7 +15,9 @@ $root = $PSScriptRoot
 # Generate Manifests
 Write-Host "Generating manifests..."
 Invoke-Kustomize -BasePath "$root/build/crds" -OutputFilePath "$root/crds/generated.yaml"
+Write-Output "{{ if ne .Values.operator.enabled false }}" | Out-File -FilePath "$root/templates/generated.yaml"
 Invoke-Kustomize -BasePath "$root/build/templates" -OutputFilePath "$root/templates/generated.yaml"
+Write-Output "{{ end }}" | Out-File -Append -FilePath "$root/templates/generated.yaml"
 
 # Package
 Write-Host "Linting chart."

--- a/manifests/helm/templates/NOTES.txt
+++ b/manifests/helm/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{ .Chart.Name }} version {{ .Chart.Version }} deployed!
+{{ .Chart.Name }} chart version {{ .Chart.Version }} deployed!
 
 {{- if .Values.agentInjectors.enabled }}
 ✅ {{ len .Values.agentInjectors.injectors }} {{ len .Values.agentInjectors.injectors | plural "injector" "injectors" }} {{ len .Values.agentInjectors.injectors | plural "has" "have" }} been deployed to {{ len .Values.agentInjectors.namespaces | plural "namespace" "namespaces" }}: {{ join ", " .Values.agentInjectors.namespaces}}
@@ -32,9 +32,12 @@
 {{- else }}
 ⚠️  clusterDefaults.enabled was false, so no agent connections deployed. Enable this and provide agent credentials for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#clusteragentconnection or https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentconnection
 {{- end }}
-
+{{ if .Values.operator.enabled }}
 👀 To watch the operator logs:
     ⎈ kubectl logs -f -l app.kubernetes.io/part-of=contrast-agent-operator --namespace {{ .Values.namespace }}
+{{- else }}
+⚠️ operator.enabled was false, Contrast operator was not included in this deployment.
+{{- end }}
 
 📄 More documentation: https://docs.contrastsecurity.com/en/agent-operator.html
 

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -17,6 +17,8 @@ imageCredentials:
   email:
 
 operator:
+  # If enabled, deploy the operator. Disable if you want to deploy only configuration resources (injectors, cluster defaults).
+  enabled: true
   # The default registry to use, defaults to docker.io/contrast.
   defaultRegistry: contrast
   # The settle duration in seconds.


### PR DESCRIPTION
This allows you to deploy the operator or configuration (agent injectors/cluster defaults) independently from one another.