### PR TITLE
🔧 Allow using an existing secret in cluster defaults

### DIFF
--- a/manifests/helm/templates/NOTES.txt
+++ b/manifests/helm/templates/NOTES.txt
@@ -29,6 +29,15 @@
 
 {{ if .Values.clusterDefaults.enabled }}
 ✅ Cluster agent defaults deployed
+{{- if .Values.clusterDefaults.existingSecret }}
+🔐 Agent credentials will be retrieved from a secret named {{ .Values.namespace }}/{{ .Values.clusterDefaults.existingSecret }}
+  The secret can be created with a command like the following:
+    ⎈ kubectl create secret generic {{ .Values.clusterDefaults.existingSecret }} --namespace {{ .Values.namespace }} \
+       --from-literal=apiKey=YOUR_API_KEY --from-literal=serviceKey=YOUR_AGENT_SERVICE_KEY --from-literal=userName=YOUR_AGENT_USERNAME
+  ⚠️  Injection will not work until this secret is created.
+
+  Refer to documentation on how to find agent keys: https://docs.contrastsecurity.com/en/find-the-agent-keys.html
+{{- end }}
 {{- else }}
 ⚠️  clusterDefaults.enabled was false, so no agent connections deployed. Enable this and provide agent credentials for easier deployment via this chart, or refer to documentation here to manually create them: https://docs.contrastsecurity.com/en/agent-operator-configuration.html#clusteragentconnection or https://docs.contrastsecurity.com/en/agent-operator-configuration.html#agentconnection
 {{- end }}

--- a/manifests/helm/templates/cluster-defaults.yaml.tpl
+++ b/manifests/helm/templates/cluster-defaults.yaml.tpl
@@ -23,15 +23,16 @@ spec:
       url: >-
         {{ required "The key clusterDefaults.clusterDefaults must be set if clusterDefaults.enabled is true" .Values.clusterDefaults.url }}
       apiKey:
-        secretName: default-agent-connection-secret
+        secretName: {{ .Values.clusterDefaults.existingSecret | default "default-agent-connection-secret" }}
         secretKey: apiKey
       serviceKey:
-        secretName: default-agent-connection-secret
+        secretName: {{ .Values.clusterDefaults.existingSecret | default "default-agent-connection-secret" }}
         secretKey: serviceKey
       userName:
-        secretName: default-agent-connection-secret
+        secretName: {{ .Values.clusterDefaults.existingSecret | default "default-agent-connection-secret" }}
         secretKey: userName
 ---
+{{if not .Values.clusterDefaults.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -41,9 +42,10 @@ metadata:
 type: Opaque
 stringData:
   apiKey: >-
-    {{ required "The key clusterDefaults.apiKeyValue must be set if clusterDefaults.enabled is true" .Values.clusterDefaults.apiKeyValue }}
+    {{ required "The key clusterDefaults.apiKeyValue must be set if clusterDefaults.enabled is true and clusterDefaults.existingSecret is not set" .Values.clusterDefaults.apiKeyValue }}
   serviceKey: >-
-    {{ required "The key clusterDefaults.serviceKeyValue must be set if clusterDefaults.enabled is true" .Values.clusterDefaults.serviceKeyValue }}
+    {{ required "The key clusterDefaults.serviceKeyValue must be set if clusterDefaults.enabled is true and clusterDefaults.existingSecret is not set" .Values.clusterDefaults.serviceKeyValue }}
   userName: >-
-    {{ required "The key clusterDefaults.userNameValue must be set if clusterDefaults.enabled is true" .Values.clusterDefaults.userNameValue }}
+    {{ required "The key clusterDefaults.userNameValue must be set if clusterDefaults.enabled is true and clusterDefaults.existingSecret is not set" .Values.clusterDefaults.userNameValue }}
+{{ end }}
 {{ end }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -59,12 +59,16 @@ clusterDefaults:
   enabled: false
   # Required. The Contrast UI instance to use. Defaults at the general SAAS instance.
   url: https://app.contrastsecurity.com/Contrast
-  # Required. The API Key from the Contrast UI.
+  # Name of a secret to retrieve the cluster-wide connection details from.
+  # The secret should contain keys named apiKey, serviceKey and userName.
+  # Leave blank if you want the chart to create a secret using the subsequent apiKeyValue, serviceKeyValue and userNameValue values.
+  existingSecret: 
+  # Required if existingSecret is not set. The API Key from the Contrast UI.
   apiKeyValue:
-  # Required. The Service Key from the Contrast UI.
-  serviceKeyValue:
+  # Required if existingSecret is not set. The Service Key from the Contrast UI.
+  serviceKeyValue if existingSecret is not set:
   # Required. The User Name from the Contrast UI.
-  userNameValue:
+  userNameValue if existingSecret is not set:
   # Optional. Any custom configuration to use. Must be in the format of the standard YAML file.
   yaml: |-
     enable: true


### PR DESCRIPTION
When a named existingSecret value is provided in cluster defaults, use that to setup the ClusterAgentConnection.