### PR TITLE
Deprecate Namespace Resource in Helm Chart in favour of helms --creat…

### DIFF
--- a/manifests/helm/build/templates/kustomization.yaml
+++ b/manifests/helm/build/templates/kustomization.yaml
@@ -1,5 +1,5 @@
 namespace: >-
-  {{ .Values.namespace }}
+  {{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}{{.Values.namespace}}{{end}}
 
 bases:
   - ../../../install/all/operator
@@ -13,3 +13,4 @@ images:
 
 patchesStrategicMerge:
   - overlays/deployment.yaml
+  - overlays/namespace.yaml

--- a/manifests/helm/build/templates/overlays/namespace.yaml
+++ b/manifests/helm/build/templates/overlays/namespace.yaml
@@ -1,0 +1,8 @@
+$patch: delete
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: contrast-agent-operator
+  labels:
+    app.kubernetes.io/part-of: contrast-agent-operator
+

--- a/manifests/helm/templates/NOTES.txt
+++ b/manifests/helm/templates/NOTES.txt
@@ -1,5 +1,9 @@
 {{ .Chart.Name }} chart version {{ .Chart.Version }} deployed!
 
+{{ if .Values.createNamespace }}
+⚠️   WARNING: Creating Namespaces via Helm Chart is deprecated and will be removed in a future release.
+     Pls use helm --create-namespace flag instead.️ {{ end }}
+
 {{- if .Values.agentInjectors.enabled }}
 ✅ {{ len .Values.agentInjectors.injectors }} {{ len .Values.agentInjectors.injectors | plural "injector" "injectors" }} {{ len .Values.agentInjectors.injectors | plural "has" "have" }} been deployed to {{ len .Values.agentInjectors.namespaces | plural "namespace" "namespaces" }}: {{ join ", " .Values.agentInjectors.namespaces}}
   To use with your workloads:

--- a/manifests/helm/templates/cluster-defaults.yaml.tpl
+++ b/manifests/helm/templates/cluster-defaults.yaml.tpl
@@ -4,7 +4,7 @@ kind: ClusterAgentConfiguration
 metadata:
   name: default-agent-configuration
   namespace: >-
-    {{ .Values.namespace }}
+    {{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}{{.Values.namespace}}{{end}}
 spec:
   template:
     spec:
@@ -16,7 +16,7 @@ kind: ClusterAgentConnection
 metadata:
   name: default-agent-connection
   namespace: >-
-    {{ .Values.namespace }}
+    {{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}{{.Values.namespace}}{{end}}
 spec:
   template:
     spec:
@@ -38,7 +38,7 @@ kind: Secret
 metadata:
   name: default-agent-connection-secret
   namespace: >-
-    {{ .Values.namespace }}
+    {{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}{{.Values.namespace}}{{end}}
 type: Opaque
 stringData:
   apiKey: >-

--- a/manifests/helm/templates/image-pull-secrets.yaml.tpl
+++ b/manifests/helm/templates/image-pull-secrets.yaml.tpl
@@ -9,7 +9,7 @@ kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.pullSecretName }}
   namespace: >-
-    {{ .Values.namespace }}
+  {{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}{{.Values.Namespace}}{{end}}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/manifests/helm/templates/namespace.depricated.yaml
+++ b/manifests/helm/templates/namespace.depricated.yaml
@@ -1,0 +1,10 @@
+## This resource is deprecated and will be removed in a future release.
+## Pls use helm --create-namespace flag instead.
+{{- if .Values.createNamespace }}
+kind: Namespace
+apiVersion: v1
+metadata:
+ name: {{ .Values.namespace }}
+ labels:
+   app.kubernetes.io/part-of: contrast-agent-operator
+{{- end -}}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -1,5 +1,6 @@
-# Release.Namespace is ignored. The operator must be created in a separate namespace.
+# Specifing a namespace here is depricated and will be removed in a future release. Please use helm --namespace / --create-namespace instead.
 namespace: contrast-agent-operator
+createNamespace: true
 image:
   registry: contrast
   repository: agent-operator
@@ -62,7 +63,7 @@ clusterDefaults:
   # Name of a secret to retrieve the cluster-wide connection details from.
   # The secret should contain keys named apiKey, serviceKey and userName.
   # Leave blank if you want the chart to create a secret using the subsequent apiKeyValue, serviceKeyValue and userNameValue values.
-  existingSecret: 
+  existingSecret:
   # Required if existingSecret is not set. The API Key from the Contrast UI.
   apiKeyValue:
   # Required if existingSecret is not set. The Service Key from the Contrast UI.


### PR DESCRIPTION
Creating namespaces within Helm charts can introduce significant issues related to security, deployment consistency, and best practices.

### Assumptions About the Default Namespace
When a Helm chart dynamically creates a namespace, it often assumes that the chart itself is running in the default namespace. This is problematic because best practices dictate avoiding the default namespace for deployments to maintain a clean and organized cluster. This assumption can lead to resources being created from within the default namespace, which is not a secure or scalable practice.

### Complications with Namespace Management
If the chart is not run from the default namespace, this approach forces the creation of a new namespace from an existing one, potentially leading to an unnecessary proliferation of namespaces. For instance, if you deploy the Helm chart from a dedicated namespace, it would create yet another namespace, resulting in a cluttered environment with multiple namespaces—one for the Helm chart and another for the deployed resources.

### Security Concerns
Allowing Helm charts to create namespaces can bypass security controls, especially in environments where developers and operators lack permissions to create namespaces. This can lead to unauthorized changes and the creation of unintended or insecure environments.

### Deployment to Specific Namespaces
Deploying to specific, predetermined namespaces ensures resources are placed in the correct environment, such as staging or production. Dynamically creating namespaces risks deploying resources into unexpected namespaces, leading to misconfigurations and operational overhead.

### Avoiding the Default Namespace
Using dynamic namespaces can result in deployments ending up in the default namespace, which is discouraged. The default namespace can become cluttered, pose security risks, and complicate resource management, particularly in environments with multiple applications or teams.

### Best Practices
Best practices suggest managing namespaces separately from Helm charts, specifying the target namespace during deployment. This approach ensures resources are deployed consistently and securely within existing, approved namespaces, avoiding the pitfalls of dynamic namespace creation.