### PR TITLE
✨ Support helm lookup for injector namespaces

### DIFF
--- a/manifests/helm/templates/NOTES.txt
+++ b/manifests/helm/templates/NOTES.txt
@@ -1,7 +1,8 @@
 {{ .Chart.Name }} chart version {{ .Chart.Version }} deployed!
 
 {{- if .Values.agentInjectors.enabled }}
-✅ {{ len .Values.agentInjectors.injectors }} {{ len .Values.agentInjectors.injectors | plural "injector" "injectors" }} {{ len .Values.agentInjectors.injectors | plural "has" "have" }} been deployed to {{ len .Values.agentInjectors.namespaces | plural "namespace" "namespaces" }}: {{ join ", " .Values.agentInjectors.namespaces}}
+{{- $namespaces := include "contrast-agent-operator.filterInjectorNamespaces" . | fromJsonArray }}
+✅ {{ len .Values.agentInjectors.injectors }} {{ len .Values.agentInjectors.injectors | plural "injector" "injectors" }} {{ len .Values.agentInjectors.injectors | plural "has" "have" }} been deployed to {{ len $namespaces | plural "namespace" "namespaces" }}: {{ join ", " $namespaces}}
   To use with your workloads:
 
   {{- range $injector := $.Values.agentInjectors.injectors }}

--- a/manifests/helm/templates/_helpers.tpl
+++ b/manifests/helm/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+Determine namespaces applicable for deploying the agent injectors
+*/}}
+{{- define "contrast-agent-operator.filterInjectorNamespaces" -}}
+{{- $namespaceNames := list }}
+{{- if .Values.agentInjectors.lookupNamespaces.deployToAllAccessibleNamespaces }}
+  {{- $namespaces := lookup "v1" "Namespace" "" "" }}
+  {{- if $namespaces.items }}
+    {{- range $ns := $namespaces.items}}
+      {{- $include := true }}
+      {{- range $index, $exclude := default (list "gatekeeper*" "kube*") $.Values.agentInjectors.lookupNamespaces.excludePatterns }}
+        {{- if regexMatch $exclude $ns.metadata.name }}
+        {{- $include = false}}
+        {{- end }}
+      {{- end }}
+      {{- if $include }}
+        {{- $namespaceNames = append $namespaceNames $ns.metadata.name }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- $namespaceNames = list "dry-run-namespace-not-representative-of-reality" }}
+  {{- end }}
+{{- else }}
+  {{- $namespaceNames = default (list .Release.Namespace) .Values.agentInjectors.namespaces -}}
+{{- end }}
+{{ toJson $namespaceNames }}
+{{- end }}

--- a/manifests/helm/templates/agent-injectors.yaml.tpl
+++ b/manifests/helm/templates/agent-injectors.yaml.tpl
@@ -1,5 +1,5 @@
 {{ if .Values.agentInjectors.enabled }}
-{{- range $namespace := .Values.agentInjectors.namespaces }}
+{{- range $namespace := include "contrast-agent-operator.filterInjectorNamespaces" . | fromJsonArray }}
 {{- range $injector := $.Values.agentInjectors.injectors }}
 ---
 apiVersion: agents.contrastsecurity.com/v1beta1

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -75,7 +75,14 @@ clusterDefaults:
 
 agentInjectors:
   enabled: true
-  # Required. All injectors will be created in each specified namespace.
+  lookupNamespaces:
+    # If enabled, Helm will lookup namespaces and deploy AgentInjectors to any accessible namespaces.
+    deployToAllAccessibleNamespaces: false
+    # List of namespace patterns to exclude deploying AgentInjectors to only when looking up namespaces.
+    excludePatterns:
+      - gatekeeper*
+      - kube*
+  # Required if lookupNamespaces.deployToAllAccessibleNamespaces is not enabled. All injectors will be created in each specified namespace.
   namespaces:
     - default
   injectors:


### PR DESCRIPTION
Allow opt-in lookup of namespaces to deploy `AgentInjector`s to within the chart, so you don't have to list namespaces yourself and pass them to helm at install time.

If enabled, helm will lookup namespaces accessible to its user, exclude those matching the patterns list, and deploy agent injectors to them all.
If we in future have a native multi-namespace injector, exclusion config here could possibly be referenced as the default for backward compatibility if the values file is not updated at install time.
