### PR TITLE
DOTNET-5968 Add extra information to /metrics endpoint (SUP-5887)

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Controllers/MetricsController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/MetricsController.cs
@@ -1,18 +1,24 @@
 ﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Contrast.K8s.AgentOperator.Core.Telemetry;
 using Contrast.K8s.AgentOperator.Core.Telemetry.Services.Metrics;
 using Microsoft.AspNetCore.Mvc;
+using NLog;
 
 namespace Contrast.K8s.AgentOperator.Controllers;
 
 [ApiController, Route("api/v1/metrics")]
 public class MetricsController : Controller
 {
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
     private readonly StatusReportGenerator _reportGenerator;
     private readonly DefaultTagsFactory _defaultTagsFactory;
 
@@ -30,12 +36,17 @@ public class MetricsController : Controller
         // Combine the Values and Tags from the report into a single output
         var output = new Dictionary<string, object>();
 
-        foreach (var value in report.Values)
+        foreach (var value in report.Values.OrderBy(r => r.Key))
         {
             output.Add(value.Key, value.Value);
         }
 
-        foreach (var tag in report.ExtraTags)
+        foreach (var stat in GenerateProcessingStatistics())
+        {
+            output.Add(stat.Key, stat.Value);
+        }
+
+        foreach (var tag in report.ExtraTags.OrderBy(r => r.Key))
         {
             output.Add(tag.Key, tag.Value);
         }
@@ -48,5 +59,78 @@ public class MetricsController : Controller
     {
         var tags = await _defaultTagsFactory.GetDefaultTags();
         return Ok(tags);
+    }
+
+    private IDictionary<string, object> GenerateProcessingStatistics()
+    {
+        var statistics = new Dictionary<string, object>();
+
+        try
+        {
+            var currentProcess = Process.GetCurrentProcess();
+
+            // Do them in groups because they can all throw InvalidOperationException/NotSupportedException
+            // Makes the code messier, but it means we'll still get as many as we can if some don't work
+            try
+            {
+                statistics.Add("Process.WorkingSet64", currentProcess.WorkingSet64);
+                statistics.Add("Process.MinWorkingSet", currentProcess.MinWorkingSet.ToInt64());
+                statistics.Add("Process.MaxWorkingSet", currentProcess.MaxWorkingSet.ToInt64());
+                statistics.Add("Process.PeakWorkingSet64", currentProcess.PeakWorkingSet64);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex);
+            }
+
+            try
+            {
+                statistics.Add("Process.PrivateMemorySize64", currentProcess.PrivateMemorySize64);
+                statistics.Add("Process.VirtualMemorySize64", currentProcess.VirtualMemorySize64);
+                statistics.Add("Process.PeakVirtualMemorySize64", currentProcess.PeakVirtualMemorySize64);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex);
+            }
+
+            try
+            {
+                statistics.Add("Process.PagedMemorySize64", currentProcess.PagedMemorySize64);
+                statistics.Add("Process.PeakPagedMemorySize64", currentProcess.PeakPagedMemorySize64);
+                statistics.Add("Process.NonpagedSystemMemorySize64", currentProcess.NonpagedSystemMemorySize64);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex);
+            }
+
+            try
+            {
+                statistics.Add("Process.TotalProcessorTime", currentProcess.TotalProcessorTime);
+                statistics.Add("Process.UserProcessorTime", currentProcess.UserProcessorTime);
+                statistics.Add("Process.PrivilegedProcessorTime", currentProcess.PrivilegedProcessorTime);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex);
+            }
+
+            try
+            {
+                statistics.Add("Process.Thread", currentProcess.Threads.Count);
+                statistics.Add("Process.Modules", currentProcess.Modules.Count);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex);
+        }
+
+        return statistics;
     }
 }

--- a/src/Contrast.K8s.AgentOperator/Controllers/MetricsController.cs
+++ b/src/Contrast.K8s.AgentOperator/Controllers/MetricsController.cs
@@ -1,6 +1,7 @@
 ﻿// Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Contrast.K8s.AgentOperator.Core.Telemetry;
@@ -25,10 +26,23 @@ public class MetricsController : Controller
     public async Task<IActionResult> GetMetrics(CancellationToken cancellationToken = default)
     {
         var report = await _reportGenerator.Generate(cancellationToken);
-        return Ok(report.Values);
+
+        // Combine the Values and Tags from the report into a single output
+        var output = new Dictionary<string, object>();
+
+        foreach (var value in report.Values)
+        {
+            output.Add(value.Key, value.Value);
+        }
+
+        foreach (var tag in report.ExtraTags)
+        {
+            output.Add(tag.Key, tag.Value);
+        }
+
+        return Ok(output);
     }
 
-    
     [HttpGet("tags")]
     public async Task<IActionResult> GetTags(CancellationToken cancellationToken = default)
     {

--- a/src/Contrast.K8s.AgentOperator/Core/Telemetry/DefaultTagsFactory.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Telemetry/DefaultTagsFactory.cs
@@ -40,9 +40,9 @@ public class DefaultTagsFactory
     {
         var defaultTags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            { "IsLeader", _leaderElectionState.IsLeader().ToString() },
             { "Operator.IsPublicBuild", _isPublicTelemetryBuildGetter.IsPublicBuild().ToString() },
-            { "Operator.Version", _telemetryState.OperatorVersion }
+            { "Operator.Version", _telemetryState.OperatorVersion },
+            { "Operator.IsLeader", _leaderElectionState.IsLeader().ToString() }
         };
 
         if (!string.IsNullOrWhiteSpace(_telemetryOptions.InstallSource))

--- a/src/Contrast.K8s.AgentOperator/Core/Telemetry/Services/Metrics/StatusReportGenerator.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Telemetry/Services/Metrics/StatusReportGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Contrast.K8s.AgentOperator.Core.Leading;
 using Contrast.K8s.AgentOperator.Core.State;
 using Contrast.K8s.AgentOperator.Core.State.Resources;
 using Contrast.K8s.AgentOperator.Core.Telemetry.Counters;
@@ -17,12 +18,18 @@ public class StatusReportGenerator
 {
     private readonly TelemetryState _telemetryState;
     private readonly IStateContainer _clusterState;
+    private readonly ILeaderElectionState _leaderElectionState;
     private readonly PerformanceCounterContainer _performanceCounterContainer;
 
-    public StatusReportGenerator(TelemetryState telemetryState, IStateContainer clusterState, PerformanceCounterContainer performanceCounterContainer)
+    public StatusReportGenerator(
+        TelemetryState telemetryState,
+        IStateContainer clusterState,
+        ILeaderElectionState leaderElectionState,
+        PerformanceCounterContainer performanceCounterContainer)
     {
         _telemetryState = telemetryState;
         _clusterState = clusterState;
+        _leaderElectionState = leaderElectionState;
         _performanceCounterContainer = performanceCounterContainer;
     }
 
@@ -52,7 +59,8 @@ public class StatusReportGenerator
 
         return new TelemetryMeasurement("status-report")
         {
-            Values = values
+            Values = values,
+            ExtraTags = GetExtraTags()
         };
     }
 
@@ -118,5 +126,13 @@ public class StatusReportGenerator
         }
 
         return metrics;
+    }
+
+    private Dictionary<string, string> GetExtraTags()
+    {
+        return new Dictionary<string, string>
+        {
+            { "IsLeader", _leaderElectionState.IsLeader().ToString() }
+        };
     }
 }


### PR DESCRIPTION
https://contrast.atlassian.net/browse/DOTNET-5968

From https://contrast.atlassian.net/browse/SUP-5887?focusedCommentId=492466:

```
Create a new release of the Agent Operator with the following:
- Additional information exposed via the /metrics endpoint (still researching how we do some of this)
  - Native cpu/memory usage of the Operator
  - Pod cpu/memory limits from the K8s API
  - "IsLeader" flag
- Extra logging to diagnose the uncaught .NET Exception that is causing the restart
  - We think it’s an "Out of Memory" exception, but need to confirm this
  - Currently dmesg just shows `.NET ThreadPool[1547673] general protection fault ip:7f54186ec50f sp:7f539e2d0c60 error:0 in libc.so.6`
```