### PR TITLE
DOTNET-5980 Quote generated AgentConfiguration yaml values

### DIFF
--- a/manifests/examples/testing/scenarios/cluster/cluster-agent-configuration.yaml
+++ b/manifests/examples/testing/scenarios/cluster/cluster-agent-configuration.yaml
@@ -10,6 +10,7 @@ spec:
         enabled: false
         foo:
           bar: "foobar"
+        special: "%specialyaml"
       initContainer:
         securityContext:
           runAsUser: 499

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Defaults/ClusterAgentConfigurationSyncingHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Defaults/ClusterAgentConfigurationSyncingHandler.cs
@@ -41,7 +41,7 @@ public class ClusterAgentConfigurationSyncingHandler
         foreach (var yamlKey in desiredResource.YamlKeys)
         {
             // Hard code the new line for Linux.
-            builder.Append(yamlKey.Key).Append(": ").Append(yamlKey.Value).Append('\n');
+            builder.Append(yamlKey.Key).Append(": '").Append(yamlKey.Value).Append("'\n");
         }
 
         var yaml = builder.ToString();

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/ClusterDefaultTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/ClusterDefaultTests.cs
@@ -84,6 +84,24 @@ public class ClusterDefaultTests : IClassFixture<TestingContext>
     }
 
     [Fact]
+    public async Task When_injected_then_pod_should_use_generated_valid_configuration()
+    {
+        var client = await _context.GetClient();
+
+        // Act
+        var result = await client.GetInjectedPodByPrefix(ScenarioName);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            var container = result.Spec.Containers.Single();
+
+            //Test that the namespaced AgentConfiguration contains valid yaml (% unquoted in yaml means its a directive line)
+            container.Env.Should().Contain(x => x.Name == "CONTRAST__SPECIAL").Which.Value.Should().Be("%specialyaml");
+        }
+    }
+
+    [Fact]
     public async Task When_init_container_overrides_exist_then_the_overrides_should_be_merged_and_applied()
     {
         var client = await _context.GetClient();


### PR DESCRIPTION
Fixes invalid yaml generated from ClusterAgentConfiguration

ClusterAgentConfiguration
```
yaml: |
  enabled: false
  foo:
    bar: "foobar"
  special: "%specialyaml"
```

AgentConfiguration
```
yaml: |
  enabled: 'false'
  foo.bar: 'foobar'
  special: '%specialyaml'
```
