### PR TITLE
AO-10 Fix readonlyfilesystem breaking asp.net core buffering in some cases

### DIFF
--- a/manifests/install/all/operator/base/deployment.yaml
+++ b/manifests/install/all/operator/base/deployment.yaml
@@ -92,3 +92,10 @@ spec:
             requests:
               cpu: 500m
               memory: 256Mi
+          volumeMounts: # We set readOnlyRootFilesystem but ASP.NET Core will buffer requests to disk under high load
+            - name: tmpfs
+              mountPath: /tmp
+      volumes:
+        - name: tmpfs
+          emptyDir:
+            sizeLimit: 50Mi


### PR DESCRIPTION
 Add writable /tmp volume for asp.net core to buffer requests to