### PR TITLE
AO-56 Move helm chart gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,4 +273,3 @@ publish*/
 
 # Dotcover snapshots.
 *.dcvr
-/manifests/generated

--- a/manifests/.gitignore
+++ b/manifests/.gitignore
@@ -1,0 +1,4 @@
+/helm/crds/generated.yaml
+/helm/templates/generated.yaml
+/helm/dist/
+/generated/

--- a/manifests/helm/.gitignore
+++ b/manifests/helm/.gitignore
@@ -1,3 +1,0 @@
-crds/generated.yaml
-templates/generated.yaml
-dist/


### PR DESCRIPTION
Move .gitignore out of helm charts directory for users that commit the published helm charts to git, while still ignoring generated files for local development.