### PR TITLE
AO-31/AO-66 Add arm64 support

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,6 +63,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         id: buildx
         with:
@@ -88,6 +92,7 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          platforms: "linux/amd64,linux/arm64"
           push: ${{ github.event_name != 'pull_request' }} # don't push the image for PR builds
           cache-from: ${{ github.actor != 'dependabot[bot]' && format('type=registry,ref={0}:cache', env.IMAGE_NAME) || ''}}
           cache-to: ${{ github.actor != 'dependabot[bot]' && format('type=registry,ref={0}:cache,mode=max', env.IMAGE_NAME) || ''}}

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
@@ -25,7 +25,7 @@ public class DotNetAgentPatcher : IAgentPatcher
         if (_injectorOptions.EnableEarlyChaining)
         {
             yield return new V1EnvVar("LD_PRELOAD",
-                $"{context.AgentMountPath}/runtimes/linux-x64/native/ContrastChainLoader.so");
+                $"{context.AgentMountPath}/runtimes/linux/native/ContrastChainLoader.so");
         }
         else
         {
@@ -63,7 +63,7 @@ public class DotNetAgentPatcher : IAgentPatcher
         {
             container.Env.AddOrUpdate(new V1EnvVar("CONTRAST_EXISTING_LD_PRELOAD", currentLdPreloadValue));
             container.Env.AddOrUpdate(new V1EnvVar("LD_PRELOAD",
-                $"{context.AgentMountPath}/runtimes/linux-x64/native/ContrastChainLoader.so:{currentLdPreloadValue}"));
+                $"{context.AgentMountPath}/runtimes/linux/native/ContrastChainLoader.so:{currentLdPreloadValue}"));
         }
     }
 

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/Agents/DotNetPatcher.cs
@@ -31,6 +31,7 @@ public class DotNetAgentPatcher : IAgentPatcher
         {
             yield return new V1EnvVar("CORECLR_PROFILER", "{8B2CE134-0948-48CA-A4B2-80DDAD9F5791}");
             yield return new V1EnvVar("CORECLR_PROFILER_PATH", $"{context.AgentMountPath}/runtimes/linux-x64/native/ContrastProfiler.so");
+            yield return new V1EnvVar("CORECLR_PROFILER_PATH_ARM64", $"{context.AgentMountPath}/runtimes/linux-arm64/native/ContrastProfiler.so");
             yield return new V1EnvVar("CORECLR_ENABLE_PROFILING", "1");
         }
 

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DotnetChainingInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DotnetChainingInjectionTests.cs
@@ -36,7 +36,7 @@ public class DotnetChainingInjectionTests : IClassFixture<TestingContext>
             var container = result.Spec.Containers.Should().ContainSingle().Subject;
 
             container.Env.Should().Contain(x => x.Name == "LD_PRELOAD")
-                     .Which.Value.Should().Be("/contrast/agent/runtimes/linux-x64/native/ContrastChainLoader.so:something");
+                     .Which.Value.Should().Be("/contrast/agent/runtimes/linux/native/ContrastChainLoader.so:something");
             container.Env.Should().Contain(x => x.Name == "CONTRAST_EXISTING_LD_PRELOAD")
                      .Which.Value.Should().Be("something");
         }

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DotnetInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DotnetInjectionTests.cs
@@ -39,6 +39,8 @@ public class DotnetInjectionTests : IClassFixture<TestingContext>
                      .Which.Value.Should().Be("{8B2CE134-0948-48CA-A4B2-80DDAD9F5791}");
             container.Env.Should().Contain(x => x.Name == "CORECLR_PROFILER_PATH")
                      .Which.Value.Should().Be("/contrast/agent/runtimes/linux-x64/native/ContrastProfiler.so");
+            container.Env.Should().Contain(x => x.Name == "CORECLR_PROFILER_PATH_ARM64")
+                .Which.Value.Should().Be("/contrast/agent/runtimes/linux-arm64/native/ContrastProfiler.so");
             container.Env.Should().Contain(x => x.Name == "CORECLR_ENABLE_PROFILING")
                      .Which.Value.Should().Be("1");
             container.Env.Should().Contain(x => x.Name == "CONTRAST_INSTALL_SOURCE")

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
@@ -27,6 +27,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
             {
                 "CORECLR_PROFILER",
                 "CORECLR_PROFILER_PATH",
+                "CORECLR_PROFILER_PATH_ARM64",
                 "CORECLR_ENABLE_PROFILING",
                 "CONTRAST_INSTALL_SOURCE",
                 "CONTRAST_INSTALLATION_TOOL",

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/Patching/Agents/DotNetPatcherTests.cs
@@ -87,7 +87,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting.Patching.Age
                          .Contain(x => x.Name == "CONTRAST_EXISTING_LD_PRELOAD" && x.Value == existingPreload);
                 container.Env.Should().Contain(x =>
                     x.Name == "LD_PRELOAD" && x.Value ==
-                    $"{context.AgentMountPath}/runtimes/linux-x64/native/ContrastChainLoader.so:{existingPreload}");
+                    $"{context.AgentMountPath}/runtimes/linux/native/ContrastChainLoader.so:{existingPreload}");
             }
         }
 


### PR DESCRIPTION
Add arm64 agent-operator image, agent-operator-images is already updated with arm64 images for each agent.

Blocked by https://github.com/Contrast-Security-OSS/agent-operator-images/pull/450 (which is blocked by the next dotnet-agent release)