### PR TITLE
AO-67 Default helm's values namespace to empty

### DIFF
--- a/manifests/helm/values.testing.yaml
+++ b/manifests/helm/values.testing.yaml
@@ -8,7 +8,6 @@ clusterDefaults:
     enable: true
     second-line: something
 
-namespace: contrast-agent-operator
 image:
   registry: contrast
   repository: agent-operator

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -1,6 +1,6 @@
 # Namespace for the agent-operator, will be created if specified.
 # When left blank the Helm namespace will be used and can be changed using `helm -n <namespace>`. Helm's `--create-namespace` option should be used when the Helm namespace does not exist and should be created.
-namespace: contrast-agent-operator
+namespace:
 image:
   registry: contrast
   repository: agent-operator


### PR DESCRIPTION
The is a follow up to #267 and will now default the values.yaml `namespace` key to empty. Using helm's --namespace argument is now preferred but the `namespace` in values.yaml can still be used and will take precedence.