### PR TITLE
Add optional initContainer ephemeral-storage requests/limits

### DIFF
--- a/manifests/helm/templates/operator/deployment.yaml.tpl
+++ b/manifests/helm/templates/operator/deployment.yaml.tpl
@@ -99,6 +99,14 @@ spec:
               value: '{{ .Values.operator.initContainer.resources.requests.memory }}'
             - name: CONTRAST_INITCONTAINER_MEMORY_LIMIT
               value: '{{ .Values.operator.initContainer.resources.limits.memory }}'
+            {{- if .Values.operator.initContainer.resources.requests.ephemeralStorage }}
+            - name: CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_REQUEST
+              value: '{{ .Values.operator.initContainer.resources.requests.ephemeralStorage }}'
+            {{- end}}
+            {{- if .Values.operator.initContainer.resources.limits.ephemeralStorage }}
+            - name: CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_LIMIT
+              value: '{{ .Values.operator.initContainer.resources.limits.ephemeralStorage }}'
+            {{- end}}
           livenessProbe:
             httpGet:
               path: /health

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -51,9 +51,11 @@ operator:
       limits:
         cpu: 100m
         memory: 64Mi
+        #ephemeralStorage:
       requests:
         cpu: 100m
         memory: 64Mi
+        #ephemeralStorage:
 
 clusterDefaults:
   # If enabled, configure cluster-wide defaults.

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/Patching/PodPatcher.cs
@@ -200,9 +200,17 @@ public class PodPatcher : IPodPatcher
         resources.Requests.TryAdd("cpu", new ResourceQuantity(_initOptions.CpuRequest));
         resources.Requests.TryAdd("memory", new ResourceQuantity(_initOptions.MemoryRequest));
 
+        if (!string.IsNullOrEmpty(_initOptions.EphemeralStorageRequest)) {
+            resources.Requests.TryAdd("ephemeral-storage", new ResourceQuantity(_initOptions.EphemeralStorageRequest));
+        }
+
         resources.Limits ??= new Dictionary<string, ResourceQuantity>(StringComparer.Ordinal);
         resources.Limits.TryAdd("cpu", new ResourceQuantity(_initOptions.CpuLimit));
         resources.Limits.TryAdd("memory", new ResourceQuantity(_initOptions.MemoryLimit));
+
+        if (!string.IsNullOrEmpty(_initOptions.EphemeralStorageLimit)) {
+            resources.Limits.TryAdd("ephemeral-storage", new ResourceQuantity(_initOptions.EphemeralStorageLimit));
+        }
 
         var initContainer = new V1Container("contrast-init")
         {

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -125,7 +125,19 @@ public class OptionsModule : Module
                 memoryLimit = memoryLimitStr;
             }
 
-            return new InitContainerOptions(cpuRequest, cpuLimit, memoryRequest, memoryLimit);
+            string? storageLimit = null;
+            string? storageRequest = null;
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_LIMIT", out var ephemeralStorageLimitStr)) {
+                logger.LogOptionValue("initcontainer-ephemeralstorage-limit", null, ephemeralStorageLimitStr);
+                storageLimit = ephemeralStorageLimitStr;
+            }
+
+            if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_REQUEST", out var ephemeralStorageRequestStr)) {
+                logger.LogOptionValue("initcontainer-ephemeralstorage-request", null, ephemeralStorageRequestStr);
+                storageRequest = ephemeralStorageRequestStr;
+            }
+
+            return new InitContainerOptions(cpuRequest, cpuLimit, memoryRequest, memoryLimit, storageRequest, storageLimit);
         }).SingleInstance();
 
         builder.Register(context =>

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -128,12 +128,12 @@ public class OptionsModule : Module
             string? storageLimit = null;
             string? storageRequest = null;
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_LIMIT", out var ephemeralStorageLimitStr)) {
-                logger.LogOptionValue("initcontainer-ephemeralstorage-limit", null, ephemeralStorageLimitStr);
+                logger.LogOptionValue("initcontainer-ephemeralstorage-limit", "null", ephemeralStorageLimitStr);
                 storageLimit = ephemeralStorageLimitStr;
             }
 
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_REQUEST", out var ephemeralStorageRequestStr)) {
-                logger.LogOptionValue("initcontainer-ephemeralstorage-request", null, ephemeralStorageRequestStr);
+                logger.LogOptionValue("initcontainer-ephemeralstorage-request", "null", ephemeralStorageRequestStr);
                 storageRequest = ephemeralStorageRequestStr;
             }
 

--- a/src/Contrast.K8s.AgentOperator/Options/InitContainerOptions.cs
+++ b/src/Contrast.K8s.AgentOperator/Options/InitContainerOptions.cs
@@ -7,4 +7,6 @@ public record InitContainerOptions(
     string CpuRequest,
     string CpuLimit,
     string MemoryRequest,
-    string MemoryLimit);
+    string MemoryLimit,
+    string? EphemeralStorageRequest,
+    string? EphemeralStorageLimit);


### PR DESCRIPTION
Allow specifying `ephemeral-storage` requests and limits on the initContainers added by the operator.
Specify via environment variables on the operator pod, `CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_REQUEST` and `CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_LIMIT` respectively.
Also available via Helm chart in `.Values.operator.initContainer.resources.requests.ephemeralStorage` / `.Values.operator.initContainer.resources.limits.ephemeralStorage`

Tested with a cluster with the following defined limits:
```yaml
apiVersion: v1
kind: LimitRange
metadata:
  name: limits
spec:
  limits:
  - max:
      cpu: "1"
      memory: 2Gi
    type: Pod
  - default:
      cpu: "1"
      ephemeral-storage: 10Gi
      memory: 512Mi
    defaultRequest:
      cpu: 50m
      ephemeral-storage: 2Gi
      memory: 512Mi
    max:
      cpu: "1"
      ephemeral-storage: 10Gi
      memory: 1Gi
    type: Container
  - min:
      storage: 1Gi
    type: PersistentVolumeClaim
```
Without variables set, our initContainer cannot be scheduled, failing with e.g. `Error creating: pods "lab-webgoat-56f65cd649-l5rqj" is forbidden: maximum ephemeral-storage usage per Container is 10Gi.  No limit is specified`
Once set, initContainer can be scheduled. 