### PR TITLE
AO-75 Default ephemeral-storage to 400Mi

### DIFF
--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -51,11 +51,11 @@ operator:
       limits:
         cpu: 100m
         memory: 64Mi
-        ephemeralStorage: 10Mi
+        ephemeralStorage: 400Mi # Needs to be greater than the size of the largest agent
       requests:
         cpu: 100m
         memory: 64Mi
-        ephemeralStorage: 10Mi
+        ephemeralStorage: 400Mi # Needs to be greater than the size of the largest agent
 
 clusterDefaults:
   # If enabled, configure cluster-wide defaults.

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -125,8 +125,9 @@ public class OptionsModule : Module
                 memoryLimit = memoryLimitStr;
             }
 
-            var storageLimit = "10Mi";
-            var storageRequest = "10Mi";
+            // Needs to be greater than the size of the largest agent
+            var storageLimit = "400Mi";
+            var storageRequest = "400Mi";
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_EPHEMERALSTORAGE_LIMIT", out var ephemeralStorageLimitStr))
             {
                 logger.LogOptionValue("initcontainer-ephemeralstorage-limit", storageLimit, ephemeralStorageLimitStr);


### PR DESCRIPTION
The shared volume we mount to copy the agent from the init-container is ephemeral-storage. If the init-container runs fast enough it is not evicted due to limits but if its too slow it will be killed with the old 10Mi limit.