### PR TITLE
AO-77 Exclude kube-system and kube-node-lease from MutationWebhook

### DIFF
--- a/manifests/helm/templates/operator/webhook.yaml.tpl
+++ b/manifests/helm/templates/operator/webhook.yaml.tpl
@@ -11,6 +11,14 @@ webhooks:
     reinvocationPolicy: IfNeeded
     failurePolicy: Ignore
     timeoutSeconds: 2
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+    matchPolicy: Equivalent
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]

--- a/manifests/install/all/operator/base/webhook.yaml
+++ b/manifests/install/all/operator/base/webhook.yaml
@@ -10,6 +10,14 @@ webhooks:
     reinvocationPolicy: IfNeeded
     failurePolicy: Ignore
     timeoutSeconds: 2
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-node-lease
+    matchPolicy: Equivalent
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]

--- a/src/Contrast.K8s.AgentOperator/Contrast.K8s.AgentOperator.csproj
+++ b/src/Contrast.K8s.AgentOperator/Contrast.K8s.AgentOperator.csproj
@@ -40,7 +40,7 @@
 
         <PackageReference Include="Sigil" Version="5.0.0" />
         <PackageReference Include="KubeOps.Operator.Web" Version="9.4.1" />
-        <PackageReference Include="KubeOps.Generator" Version="9.3.0">
+        <PackageReference Include="KubeOps.Generator" Version="9.4.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Contrast.K8s.AgentOperator.FunctionalTests.csproj
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Contrast.K8s.AgentOperator.FunctionalTests.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="KubeOps.KubernetesClient" Version="9.3.0" />
+    <PackageReference Include="KubeOps.KubernetesClient" Version="9.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Exclude kube-system and kube-node-lease from MutationWebhook https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/#webhook-limit-scope
- Explicitly set matchPolicy to Equivalent (this is the default but we want to be explicit)
- Fix KubeOps package upgrade