### PR TITLE
AO-78 Upgrade dotnet-operator-sdk

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "kubeops.cli": {
-      "version": "9.4.1",
+      "version": "9.5.0",
       "commands": [
         "kubeops"
       ],

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Make sure the operator supports your cluster version.
 
 | Kubernetes Version | OpenShift Version | Operator Version | End-of-Support |
 |--------------------|-------------------|------------------|----------------|
-| v1.31              |                   | v0.14.0+         | 2025-10-28     |
-| v1.30              |                   | v0.14.0+         | 2025-06-28     |
-| v1.29              | v4.16             | v0.14.0+         | 2025-02-28     |
-| v1.28              | v4.15             | v0.14.0+         | 2024-10-28     |
-| v1.27              | v4.14             | v0.14.0+         | 2024-06-28     |
-| v1.26              | v4.13             | v0.14.0+         | 2024-02-28     |
+| v1.31              |                   | v1.0.0+         | 2025-10-28     |
+| v1.30              |                   | v1.0.0+         | 2025-06-28     |
+| v1.29              | v4.16             | v1.0.0+         | 2025-02-28     |
+| v1.28              | v4.15             | v1.0.0+         | 2024-10-28     |
+| v1.27              | v4.14             | v1.0.0+         | 2024-06-28     |
+| v1.26              | v4.13             | v1.0.0+         | 2024-02-28     |
 
 To install the latest version of the operator into a cluster, apply the installation YAML containing all the required manifests, including the CRDs and RBACs.
 

--- a/docs/public/02-supported-technologies.md
+++ b/docs/public/02-supported-technologies.md
@@ -4,12 +4,12 @@
 
 | Kubernetes Version | OpenShift Version | Operator Version | End-of-Support |
 |--------------------|-------------------|------------------|----------------|
-| v1.31              |                   | v0.14.0+         | 2025-10-28     |
-| v1.30              |                   | v0.14.0+         | 2025-06-28     |
-| v1.29              | v4.16             | v0.14.0+         | 2025-02-28     |
-| v1.28              | v4.15             | v0.14.0+         | 2024-10-28     |
-| v1.27              | v4.14             | v0.14.0+         | 2024-06-28     |
-| v1.26              | v4.13             | v0.14.0+         | 2024-02-28     |
+| v1.31              |                   | v1.0.0+         | 2025-10-28     |
+| v1.30              |                   | v1.0.0+         | 2025-06-28     |
+| v1.29              | v4.16             | v1.0.0+         | 2025-02-28     |
+| v1.28              | v4.15             | v1.0.0+         | 2024-10-28     |
+| v1.27              | v4.14             | v1.0.0+         | 2024-06-28     |
+| v1.26              | v4.13             | v1.0.0+         | 2024-02-28     |
 
 - The Contrast Agent Operator follows the upstream [Kubernetes community support policy](https://kubernetes.io/releases/patch-releases/#support-period). End-of-life dates are documented on the [Kubernetes releases](https://kubernetes.io/releases/#release-history) page.
 - OpenShift support is dependent on the included version of Kubernetes. For example, OpenShift v4.10 uses Kubernetes v1.23 and will be supported by Contrast until 2023-02-28. See Red Hat's [support article](https://access.redhat.com/solutions/4870701) for the mapping between Kubernetes and OpenShift versions.

--- a/manifests/generate-manifests.ps1
+++ b/manifests/generate-manifests.ps1
@@ -2,8 +2,8 @@
 # Run under powershell core
 #Requires -Version 6.0
 
-$project = [System.IO.Path]::GetFullPath("..\src\Contrast.K8s.AgentOperator\Contrast.K8s.AgentOperator.csproj")
-$output = [System.IO.Path]::GetFullPath(".\generated\")
+$project = [System.IO.Path]::GetFullPath("$PSScriptroot\..\src\Contrast.K8s.AgentOperator\Contrast.K8s.AgentOperator.csproj")
+$output = [System.IO.Path]::GetFullPath("$PSScriptroot\generated\")
 
 Write-Host "Project: $project"
 Write-Host "Output: $output"
@@ -19,4 +19,4 @@ dotnet kubeops generate operator contrast-agent-operator $project --out $output
     Remove-Item $_
 }
 
-Write-Host "Done. Compare with manifests in `manifests/install/all` and `manifests/helm/templates/operator` folders and merge changes."
+Write-Host "Done. Compare with manifests in `manifests/install/all` and `manifests/helm/templates/operator` folders and merge changes (CRDs and RBAC)."

--- a/manifests/install/all/operator/base/rbac/cluster-role.yaml
+++ b/manifests/install/all/operator/base/rbac/cluster-role.yaml
@@ -31,7 +31,12 @@ rules:
   resources:
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -48,7 +53,13 @@ rules:
   - agentconnections
   - agentinjectors
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - agents.contrastsecurity.com
   resources:
@@ -98,7 +109,13 @@ rules:
   resources:
   - leases
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apps
   resources:

--- a/src/Contrast.K8s.AgentOperator/Contrast.K8s.AgentOperator.csproj
+++ b/src/Contrast.K8s.AgentOperator/Contrast.K8s.AgentOperator.csproj
@@ -15,8 +15,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
         <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
         <PackageReference Include="CertificateManager" Version="1.0.9" />
         <PackageReference Include="Autofac" Version="8.2.0" />
@@ -39,8 +37,8 @@
         </PackageReference>
 
         <PackageReference Include="Sigil" Version="5.0.0" />
-        <PackageReference Include="KubeOps.Operator.Web" Version="9.4.1" />
-        <PackageReference Include="KubeOps.Generator" Version="9.4.1">
+        <PackageReference Include="KubeOps.Operator.Web" Version="9.5.0" />
+        <PackageReference Include="KubeOps.Generator" Version="9.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Contrast.K8s.AgentOperator/Core/Kube/VerbConstants.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Kube/VerbConstants.cs
@@ -9,10 +9,10 @@ public static class VerbConstants
 {
     public const RbacVerb ReadAndPatch = RbacVerb.Get | RbacVerb.List | RbacVerb.Patch | RbacVerb.Watch;
 
-    // TODO This math is wrong?
-    public const RbacVerb AllButDelete = RbacVerb.All & ~RbacVerb.Delete;
+    public const RbacVerb AllButDelete =
+        RbacVerb.Get | RbacVerb.List | RbacVerb.Watch | RbacVerb.Create | RbacVerb.Update | RbacVerb.Patch;
 
     public const RbacVerb ReadOnly = RbacVerb.Get | RbacVerb.List | RbacVerb.Watch;
 
-    public const RbacVerb FullControl = RbacVerb.All;
+    public const RbacVerb FullControl = RbacVerb.AllExplicit;
 }

--- a/src/Contrast.K8s.AgentOperator/Core/YamlParser.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/YamlParser.cs
@@ -120,13 +120,13 @@ public class YamlParser : IYamlParser
 }
 
 public record ParseResult(bool IsValid,
-                          int LineNumber = -1,
-                          int StartColumn = -1,
-                          int EndColumn = -1,
+                          long LineNumber = -1,
+                          long StartColumn = -1,
+                          long EndColumn = -1,
                           string? Error = null);
 
 public record YamlSetting(string Key,
                           string? Value,
-                          int Line,
-                          int KeyColumn,
-                          int ValueColumn);
+                          long Line,
+                          long KeyColumn,
+                          long ValueColumn);

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Contrast.K8s.AgentOperator.FunctionalTests.csproj
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Contrast.K8s.AgentOperator.FunctionalTests.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="KubeOps.KubernetesClient" Version="9.4.1" />
+    <PackageReference Include="KubeOps.KubernetesClient" Version="9.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/performance-tests/Contrast.K8s.AgentOperator.Performance.ClusterFaker/Contrast.K8s.AgentOperator.Performance.ClusterFaker.csproj
+++ b/tests/performance-tests/Contrast.K8s.AgentOperator.Performance.ClusterFaker/Contrast.K8s.AgentOperator.Performance.ClusterFaker.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Punchclock" Version="3.4.143" />
-        <PackageReference Include="KubeOps.KubernetesClient" Version="9.1.5" />
+        <PackageReference Include="KubeOps.KubernetesClient" Version="9.5.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgrade dotnet-operator-sdk to 9.5.0
- Use RbacVerb.AllExplicit instead of RbacVerb.All to generate explicit verbs in the ClusterRole RBAC instead of using '*'
- Fix manifest generator script path issue