### PR TITLE
AO-79 Fix ClusterRole permissions

### DIFF
--- a/manifests/helm/templates/operator/rbac/cluster-role.yaml.tpl
+++ b/manifests/helm/templates/operator/rbac/cluster-role.yaml.tpl
@@ -32,7 +32,13 @@ rules:
   resources:
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -49,7 +55,13 @@ rules:
   - agentconnections
   - agentinjectors
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - agents.contrastsecurity.com
   resources:
@@ -99,7 +111,13 @@ rules:
   resources:
   - leases
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apps
   resources:

--- a/manifests/install/all/operator/base/rbac/cluster-role.yaml
+++ b/manifests/install/all/operator/base/rbac/cluster-role.yaml
@@ -37,6 +37,7 @@ rules:
   - create
   - update
   - patch
+  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/src/Contrast.K8s.AgentOperator/Core/Kube/VerbConstants.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Kube/VerbConstants.cs
@@ -14,5 +14,5 @@ public static class VerbConstants
 
     public const RbacVerb ReadOnly = RbacVerb.Get | RbacVerb.List | RbacVerb.Watch;
 
-    public const RbacVerb FullControl = RbacVerb.AllExplicit;
+    public const RbacVerb All = RbacVerb.AllExplicit;
 }

--- a/src/Contrast.K8s.AgentOperator/Entities/BuiltinEntityRbac.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/BuiltinEntityRbac.cs
@@ -12,7 +12,7 @@ namespace Contrast.K8s.AgentOperator.Entities
     [EntityRbac(typeof(V1DaemonSet), Verbs = VerbConstants.ReadAndPatch)]
     [EntityRbac(typeof(V1Deployment), Verbs = VerbConstants.ReadAndPatch)]
     [EntityRbac(typeof(V1Pod), Verbs = VerbConstants.ReadAndPatch)]
-    [EntityRbac(typeof(V1Secret), Verbs = VerbConstants.AllButDelete)]
+    [EntityRbac(typeof(V1Secret), Verbs = VerbConstants.All)]
     [EntityRbac(typeof(V1MutatingWebhookConfiguration), Verbs = VerbConstants.ReadAndPatch)]
     [EntityRbac(typeof(V1StatefulSet), Verbs = VerbConstants.ReadAndPatch)]
     [UsedImplicitly]

--- a/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentConfiguration.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentConfiguration.cs
@@ -10,7 +10,7 @@ using KubeOps.Abstractions.Rbac;
 namespace Contrast.K8s.AgentOperator.Entities;
 
 [KubernetesEntity(Group = "agents.contrastsecurity.com", ApiVersion = "v1beta1", Kind = "AgentConfiguration", PluralName = "agentconfigurations")]
-[EntityRbac(typeof(V1Beta1AgentConfiguration), Verbs = VerbConstants.FullControl)]
+[EntityRbac(typeof(V1Beta1AgentConfiguration), Verbs = VerbConstants.All)]
 public partial class V1Beta1AgentConfiguration : CustomKubernetesEntity<V1Beta1AgentConfiguration.AgentConfigurationSpec>
 {
     public class AgentConfigurationSpec

--- a/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentConnection.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentConnection.cs
@@ -10,7 +10,7 @@ using KubeOps.Abstractions.Rbac;
 namespace Contrast.K8s.AgentOperator.Entities;
 
 [KubernetesEntity(Group = "agents.contrastsecurity.com", ApiVersion = "v1beta1", Kind = "AgentConnection", PluralName = "agentconnections")]
-[EntityRbac(typeof(V1Beta1AgentConnection), Verbs = VerbConstants.FullControl)]
+[EntityRbac(typeof(V1Beta1AgentConnection), Verbs = VerbConstants.All)]
 public partial class V1Beta1AgentConnection : CustomKubernetesEntity<V1Beta1AgentConnection.AgentConnectionSpec>
 {
     public class AgentConnectionSpec

--- a/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentInjector.cs
+++ b/src/Contrast.K8s.AgentOperator/Entities/V1Beta1AgentInjector.cs
@@ -12,7 +12,7 @@ using KubeOps.Abstractions.Rbac;
 namespace Contrast.K8s.AgentOperator.Entities;
 
 [KubernetesEntity(Group = "agents.contrastsecurity.com", ApiVersion = "v1beta1", Kind = "AgentInjector", PluralName = "agentinjectors")]
-[EntityRbac(typeof(V1Beta1AgentInjector), Verbs = VerbConstants.FullControl)]
+[EntityRbac(typeof(V1Beta1AgentInjector), Verbs = VerbConstants.All)]
 public partial class V1Beta1AgentInjector : CustomKubernetesEntity<V1Beta1AgentInjector.AgentInjectorSpec>
 {
     public class AgentInjectorSpec


### PR DESCRIPTION
- Re-add delete to secrets RBAC because the operator needs to be able to cleanup secrets that it created as part of ClusterAgentConnection creating AgentConnections/Secrets in each namespace specified in the ClusterAgentConnection
- Sync helm template rbac