### PR TITLE
AO-84 Stop watching entities that return 404

### DIFF
--- a/manifests/install/testing/overlays/deployment.yaml
+++ b/manifests/install/testing/overlays/deployment.yaml
@@ -13,6 +13,6 @@ spec:
             - name: CONTRAST_AGENT_TELEMETRY_OPTOUT
               value: "true"
             - name: CONTRAST_RUN_INIT_CONTAINER_AS_NON_ROOT
-              value: "false"
+              value: "true"
             - name: "CONTRAST_LOG_LEVEL"
               value: "TRACE"


### PR DESCRIPTION
If a entity returns 404 to a watch request then that entity type doesn't exist in the the k8s cluster. We stop checking for this resource instead of retying every 30 seconds. 