### PR TITLE
AO-83 Set dummy agent to a agent-dummy

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Core/AgentInjectionTypeConverter.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/AgentInjectionTypeConverter.cs
@@ -26,11 +26,7 @@ public class AgentInjectionTypeConverter : IAgentInjectionTypeConverter
 
     public string GetDefaultImageRegistry(AgentInjectionType type)
     {
-        return type switch
-        {
-            AgentInjectionType.Dummy => "docker.io/library",
-            _ => _repositoryOptions.DefaultRegistry
-        };
+        return _repositoryOptions.DefaultRegistry;
     }
 
     public string GetDefaultImageName(AgentInjectionType type)
@@ -44,7 +40,7 @@ public class AgentInjectionTypeConverter : IAgentInjectionTypeConverter
             AgentInjectionType.NodeJsLegacy => "agent-nodejs",
             AgentInjectionType.Php => "agent-php",
             AgentInjectionType.Python => "agent-python",
-            AgentInjectionType.Dummy => "busybox",
+            AgentInjectionType.Dummy => "agent-dummy",
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DummyInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/Agents/DummyInjectionTests.cs
@@ -31,6 +31,6 @@ public class DummyInjectionTests : IClassFixture<TestingContext>
 
         // Assert
         result.Spec.InitContainers.Should().ContainSingle(x => x.Name == "contrast-init")
-              .Which.Image.Should().Be("docker.io/library/busybox:latest");
+              .Which.Image.Should().Be("contrast/agent-dummy:latest");
     }
 }


### PR DESCRIPTION
`dummy` agent is used for testing, this sets it to a agent-dummy image that runs as a rootless init container.