### PR TITLE
AO-87 Publish crds as a seperate manifest

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -61,8 +61,6 @@ jobs:
       IS_PUBLIC_BUILD: ${{ needs.generate-version.outputs.is-public-build }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
       - name: Setup QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
         with:
@@ -125,11 +123,19 @@ jobs:
           cat ../../license-header.yaml > ./install-prod-quay.yaml
           kustomize build ./ >> ./install-prod-quay.yaml
         shell: bash
+      - name: Generate Manifests (CRDs)
+        run: |
+          set -xe
+          cd ./manifests/install/all/crds
+          cat ../../../license-header.yaml > ./crds.yaml
+          kustomize build ./ >> ./crds.yaml
+        shell: bash
       - name: Stage Manifests
         run: |
           set -xe
           cp manifests/install/prod/install-prod.yaml ./install-prod.yaml
           cp manifests/install/prod-quay/install-prod-quay.yaml ./install-prod-quay.yaml
+          cp manifests/install/all/crds/crds.yaml ./crds.yaml
         shell: bash
       - name: Publish (Artifacts)
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
@@ -138,6 +144,7 @@ jobs:
           path: |
             install-prod.yaml
             install-prod-quay.yaml
+            crds.yaml
           retention-days: 7
   build-helm-chart:
     runs-on: ubuntu-latest
@@ -201,8 +208,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }} # should match push logic in build-image
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
       - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -442,7 +442,9 @@ jobs:
         uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1.15.0
         with:
           body: |
-            Version v${{ env.BUILD_VERSION }} released!
+            ## Version v${{ env.BUILD_VERSION }} released!
+
+            ---
             ```
             contrast/agent-operator:${{ env.BUILD_VERSION }}
             contrast/agent-operator@${{ needs.build-image.outputs.digest }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,7 @@ Note: If you get the error `Error: Process 'PID 4 System Service' binds to port 
 
 ## Building the Operator
 
-> Make sure to restore the submodules in the `./vendor` directory and you have the latest .NET LTS installed!
+> Make sure you have the latest .NET LTS installed!
 
 The Contrast Agent Operator is a standard .NET application and can be built as such.
 


### PR DESCRIPTION
Since helm only installs CRDs on install and not upgrades it causes the CRDs to be out of date. https://helm.sh/docs/topics/charts/#limitations-on-crds  Publishing the CRDS as a separate manifest helps with upgrades because the kubectl apply/replace can be run before the helm chart upgrade like https://cert-manager.io/docs/installation/upgrade/#crds-managed-separately 

- Publish crds.yaml
- Update release template
- Remove submodules setting from checkout