### PR TITLE
AO-99 Increase init-container default memory limit

### DIFF
--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -67,7 +67,7 @@ operator:
     resources:
       limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 256Mi
         ephemeralStorage: 1Gi # Needs to be greater than the size of the largest agent
       requests:
         cpu: 100m

--- a/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
+++ b/src/Contrast.K8s.AgentOperator/Modules/OptionsModule.cs
@@ -111,7 +111,7 @@ public class OptionsModule : Module
                 cpuLimit = cpuLimitStr;
             }
 
-            var memoryLimit = "64Mi";
+            var memoryLimit = "256Mi";
             var memoryRequest = "64Mi";
             if (GetEnvironmentVariableAsString("CONTRAST_INITCONTAINER_MEMORY_REQUEST", out var memoryRequestStr))
             {

--- a/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/StandardInjectionTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.FunctionalTests/Scenarios/Injection/StandardInjectionTests.cs
@@ -216,7 +216,7 @@ public class StandardInjectionTests : IClassFixture<TestingContext>
 
             resources.Should().NotBeNull();
             resources.Limits.Should().ContainKey("cpu").WhoseValue.Value.Should().Be("100m");
-            resources.Limits.Should().ContainKey("memory").WhoseValue.Value.Should().Be("64Mi");
+            resources.Limits.Should().ContainKey("memory").WhoseValue.Value.Should().Be("256Mi");
             resources.Requests.Should().ContainKey("cpu").WhoseValue.Value.Should().Be("100m");
             resources.Requests.Should().ContainKey("memory").WhoseValue.Value.Should().Be("64Mi");
         }


### PR DESCRIPTION
Increase init-container default memory limit due to being killed while copying files to the shared volume.