### PR TITLE
[ENTSEC-0] Adding Wiz Scanning to Repo

### DIFF
--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -27,7 +27,7 @@ jobs:
         run: docker build . --tag agent-operator:dev
 
       - name: Download Wiz CLI
-        run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+        run: curl -fsSLo wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
         run: ./wizcli scan container-image agent-operator:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "$POLICY" --csv-output-file="agent-operator-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   wiz-scan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -37,6 +37,7 @@ jobs:
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
 
       - name: Capture Wiz Output
+        if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: agent-operator-wiz-report

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -40,3 +40,4 @@ jobs:
           name: agent-operator-wiz-report
           path: |
             agent-operator-wiz-report.zip
+          retention-days: 7

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       POLICY: "Contrast-OSS,EOL-Scan"
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Checkout repo

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash
     env:
-      POLICY: "Block-VM"
+      POLICY: "Contrast-OSS,EOL-Scan"
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -1,0 +1,43 @@
+name: Wiz Scan
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  wiz-scan:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      POLICY: "Block-VM"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build the Docker image
+        run: docker build . --tag agent-operator:dev
+
+      - name: Download Wiz CLI
+        run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+
+      - name: Run Wiz CLI container image scan
+        run: ./wizcli scan container-image agent-operator:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "$POLICY" --csv-output-file="agent-operator-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
+        env:
+          WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+          WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+
+      - name: Capture Wiz Output
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: agent-operator-wiz-report
+          path: |
+            agent-operator-wiz-report.zip

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/wiz-scan.yml
+++ b/.github/workflows/wiz-scan.yml
@@ -17,6 +17,7 @@ jobs:
         shell: bash
     env:
       POLICY: "Contrast-OSS,EOL-Scan"
+      WIZ_CLI_VERSION: "1.50.0"
     permissions:
       contents: read
     steps:
@@ -27,7 +28,7 @@ jobs:
         run: docker build . --tag agent-operator:dev
 
       - name: Download Wiz CLI
-        run: curl -fsSLo wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+        run: curl -fsSLo wizcli https://downloads.wiz.io/v1/wizcli/${WIZ_CLI_VERSION}/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
         run: ./wizcli scan container-image agent-operator:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "$POLICY" --csv-output-file="agent-operator-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period


### PR DESCRIPTION
What Changed:
- Added Wiz Image Scanning to Repo Workflow

Why the Change?
- Increased visibility for vulnerability management of customer facing downloadable resources
- Customer reported several CVEs asking if affected - No current visibility within Wiz
- Helps to reduce Security Footprint of downloadable resources
- Helps to increase Customer Confidence 