### PR TITLE
[ENTSEC-1] - Block workflows on Wiz Scan failure

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,13 @@ on:
 
 jobs:
   #
+  # Security Scan Stage
+  #
+  wiz-scan:
+    uses: ./.github/workflows/wiz-scan.yml
+    secrets: inherit
+
+  #
   # Building Stage
   #
   generate-version:
@@ -50,7 +57,9 @@ jobs:
         shell: pwsh
   build-image:
     runs-on: ubuntu-latest
-    needs: generate-version
+    needs:
+      - generate-version
+      - wiz-scan
     permissions:
       packages: write
     outputs:


### PR DESCRIPTION
Hey Team, this PR introduces a Block for all workflows if there is a Wiz Scan failure.  This change is being introduced to prevent starting the build processes if there is a Wiz Scan failure. This better aligns the Repo with the Contrast Security Vulnerability Management Policies.