### PR TITLE
AO-128 feat(chart): expose operator hostNetwork and dnsPolicy values

### DIFF
--- a/manifests/helm/templates/operator/deployment.yaml.tpl
+++ b/manifests/helm/templates/operator/deployment.yaml.tpl
@@ -34,6 +34,12 @@ spec:
         {{- toYaml .Values.operator.podAnnotations | nindent 8 }}
     {{- end }}
     spec:
+      {{- if .Values.operator.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.operator.dnsPolicy | default "ClusterFirstWithHostNet" }}
+      {{- else if .Values.operator.dnsPolicy }}
+      dnsPolicy: {{ .Values.operator.dnsPolicy }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -49,6 +55,22 @@ spec:
                       - amd64
                       - arm64
         podAntiAffinity:
+          {{- if .Values.operator.hostNetwork }}
+          # With hostNetwork the operator binds a host port, so at most one operator pod
+          # can run per node. Make the anti-affinity required to enforce that.
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - operator
+                  - key: app.kubernetes.io/part-of
+                    operator: In
+                    values:
+                      - contrast-agent-operator
+              topologyKey: kubernetes.io/hostname
+          {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
               podAffinityTerm:
@@ -63,6 +85,7 @@ spec:
                       values:
                         - contrast-agent-operator
                 topologyKey: kubernetes.io/hostname
+          {{- end }}
       serviceAccountName: contrast-agent-operator-service-account
       {{- if .Values.imageCredentials.pullSecretName }}
       imagePullSecrets:

--- a/manifests/helm/values.schema.json
+++ b/manifests/helm/values.schema.json
@@ -340,13 +340,22 @@
                     "default": "contrast",
                     "type": "string"
                 },
+                "dnsPolicy": {
+                    "description": "DNS policy for the operator pod. Leave unset for the Kubernetes default. Defaults to ClusterFirstWithHostNet when hostNetwork is true.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "ClusterFirst",
+                        "ClusterFirstWithHostNet",
+                        "Default",
+                        "None",
+                        null
+                    ]
+                },
                 "enableAgentStdout": {
                     "description": "Globally enable agents logging to stdout",
-                    "default": false,
-                    "type": "boolean"
-                },
-                "useImageVolumes": {
-                    "description": "Use Kubernetes image volumes (KEP-4639) instead of init containers to mount agent files. Requires Kubernetes 1.35+.",
                     "default": false,
                     "type": "boolean"
                 },
@@ -378,6 +387,11 @@
                     "description": "Max number of events to queue from the K8s event stream.",
                     "default": 10000,
                     "type": "integer"
+                },
+                "hostNetwork": {
+                    "description": "Run the operator pod on the host network so the API server can reach the injection webhook on a routable node IP. Needed on clusters where pods only have non-routable IPs (for example EKS with an overlay CNI). Requires the operator namespace to run under the privileged Pod Security Standard, so use a dedicated namespace.",
+                    "default": false,
+                    "type": "boolean"
                 },
                 "initContainer": {
                     "description": "Resource management for the agent initContainers",
@@ -543,6 +557,11 @@
                 },
                 "telemetryOptOut": {
                     "description": "Opt-Out of telemetry collection",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "useImageVolumes": {
+                    "description": "Use Kubernetes image volumes (KEP-4639) instead of init containers to mount agent files. Requires Kubernetes 1.35+.",
                     "default": false,
                     "type": "boolean"
                 },

--- a/manifests/helm/values.schema.yaml
+++ b/manifests/helm/values.schema.yaml
@@ -59,6 +59,10 @@ operator:
   telemetryOptOut: # @schema type:[boolean];default:false
   # -- Operator Log Level
   operatorLogLevel: # @schema type:[string];enum:[Trace, Debug, Info, Warn, Error];default:Info
+  # -- Run the operator pod on the host network so the API server can reach the injection webhook on a routable node IP. Needed on clusters where pods only have non-routable IPs (for example EKS with an overlay CNI). Requires the operator namespace to run under the privileged Pod Security Standard, so use a dedicated namespace.
+  hostNetwork: # @schema type:[boolean];default:false
+  # -- DNS policy for the operator pod. Leave unset for the Kubernetes default. Defaults to ClusterFirstWithHostNet when hostNetwork is true.
+  dnsPolicy: # @schema type:[string, null];enum:[ClusterFirst, ClusterFirstWithHostNet, Default, None, null]
   # -- Deployment Labels for the operator deployment.
   labels: {}
   # -- Deployment Annotations for the operator deployment.

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -59,6 +59,21 @@ operator:
   #telemetryOptOut: false
   # Operator Log Level
   operatorLogLevel: Info
+  # Run the operator pod on the node's host network so the Kubernetes API server can
+  # reach the injection webhook on a routable node IP. Needed on clusters where pods
+  # only have non-routable IPs the control plane cannot reach (for example EKS with an
+  # overlay CNI such as Calico in overlay mode), which otherwise causes the webhook call
+  # to fail silently and pods to start without the agent.
+  # Enabling host networking requires the operator namespace to run under the privileged
+  # Pod Security Standard, which removes PSS enforcement for that whole namespace, so run
+  # the operator in its own dedicated namespace when using this. The operator container
+  # keeps its hardened securityContext (runAsNonRoot, readOnlyRootFilesystem, drop ALL)
+  # regardless of this setting.
+  hostNetwork: false
+  # DNS policy for the operator pod. Leave unset for the Kubernetes default. When
+  # hostNetwork is true this defaults to ClusterFirstWithHostNet so the operator can
+  # still resolve in-cluster names via CoreDNS. Set explicitly only to override.
+  #dnsPolicy: ClusterFirstWithHostNet
   # Metadata for the operator deployment.
   labels: {}
   annotations: {}


### PR DESCRIPTION
## What

Expose two new Helm values on the operator deployment:

- `operator.hostNetwork` (bool, default `false`)
- `operator.dnsPolicy` (string, unset by default)

## Why

The operator injects via a mutating admission webhook that the Kubernetes API server must reach. On clusters where pods only receive non-routable IPs (for example EKS with an overlay CNI), the API server cannot reach the webhook, and because the webhook uses `failurePolicy: Ignore`, pods are admitted without the agent and injection fails silently with no error surfaced.

Placing the operator on the host network gives the webhook a routable node IP.

## Behavior

- Both values default off. With defaults, the rendered manifest is identical to before, so existing installs see no change and no rollout on upgrade.
- When `hostNetwork` is enabled, `dnsPolicy` defaults to `ClusterFirstWithHostNet` (overridable) so the operator still resolves in-cluster names, and the pod anti-affinity is upgraded to `required` so at most one operator pod is scheduled per node (host networking binds a node port, so two pods on one node would collide).
- `values.schema.json` regenerated from `values.schema.yaml`.
- The operator container keeps its existing hardened `securityContext` (`runAsNonRoot`, `readOnlyRootFilesystem`, drop `ALL`) regardless of this setting.

Enabling host networking requires the operator namespace to run under the privileged Pod Security Standard, which removes PSS enforcement for that namespace, so running the operator in a dedicated namespace is recommended. This is documented in the `values.yaml` comment.

## Testing

- `helm lint` and `helm template` across default and enabled permutations; confirmed the default render is byte-identical to the base branch (no impact on existing installs).
- Deployed to a live EKS cluster with `hostNetwork` enabled: the operator came up healthy on the host network (pod IP equal to node IP), the two replicas were scheduled onto separate nodes by the required anti-affinity, and a labeled test workload was injected end-to-end with the agent loading at runtime.
