### PR TITLE
[DEVOPS-14986] Un-inject a workload under OnCreate when its binding is removed

### DIFF
--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Contrast.K8s.AgentOperator.Core.Events;
 using Contrast.K8s.AgentOperator.Core.Kube;
+using Contrast.K8s.AgentOperator.Core.Reactions.Matching;
 using Contrast.K8s.AgentOperator.Core.State;
 using Contrast.K8s.AgentOperator.Core.State.Resources;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Interfaces;
@@ -28,12 +29,14 @@ public class PodTemplateInjectionHandler : INotificationHandler<InjectorMatched>
     private readonly IResourceHasher _hasher;
     private readonly IStateContainer _state;
     private readonly IResourcePatcher _patcher;
+    private readonly AgentInjectorMatcher _matcher;
 
-    public PodTemplateInjectionHandler(IResourceHasher hasher, IStateContainer state, IResourcePatcher patcher)
+    public PodTemplateInjectionHandler(IResourceHasher hasher, IStateContainer state, IResourcePatcher patcher, AgentInjectorMatcher matcher)
     {
         _hasher = hasher;
         _state = state;
         _patcher = patcher;
+        _matcher = matcher;
     }
 
     public async Task Handle(InjectorMatched notification, CancellationToken cancellationToken)
@@ -83,14 +86,26 @@ public class PodTemplateInjectionHandler : INotificationHandler<InjectorMatched>
         }
 
         var annotatedInjector = await _state.GetById<AgentInjectorResource>(annotatedName, annotatedNamespace, cancellationToken);
-        if (annotatedInjector is { ReconcilePolicy: ReconcilePolicy.OnCreate })
+
+        // Only preserve a still-valid OnCreate binding. If the annotated injector is gone,
+        // disabled, or no longer selects this workload (label removed/changed), the binding
+        // is no longer active — fall through so the empty desired state strips the injection.
+        if (annotatedInjector is not { Enabled: true, ReconcilePolicy: ReconcilePolicy.OnCreate })
         {
-            Logger.Info($"Workload '{target.Identity}' has drifted but its annotated injector '{annotatedName}/{annotatedNamespace}' "
-                        + "uses reconcilePolicy 'OnCreate'. Deferring re-patch; new settings will apply as pods are recreated.");
-            return true;
+            return false;
         }
 
-        return false;
+        var annotatedPair = new ResourceIdentityPair<AgentInjectorResource>(
+            NamespacedResourceIdentity.Create<AgentInjectorResource>(annotatedName, annotatedNamespace),
+            annotatedInjector);
+        if (!_matcher.IsMatch(annotatedPair, target))
+        {
+            return false;
+        }
+
+        Logger.Info($"Workload '{target.Identity}' has drifted but its annotated injector '{annotatedName}/{annotatedNamespace}' "
+                    + "uses reconcilePolicy 'OnCreate'. Deferring re-patch; new settings will apply as pods are recreated.");
+        return true;
     }
 
     private static bool ChangesNeeded(ResourceIdentityPair<IResourceWithPodTemplate> target, DesiredState desiredState)

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
@@ -97,6 +97,10 @@ public class PodTemplateInjectionHandler : INotificationHandler<InjectorMatched>
             return false;
         }
 
+        // Checks whether the injector that stamped this workload STILL selects it, not the
+        // current match MatchInjectorsHandler already resolved. On an un-match (label removed)
+        // the incoming injector is null but the annotated one is still enabled+OnCreate, so
+        // without this we'd defer and orphan the injection instead of stripping it.
         var annotatedPair = new ResourceIdentityPair<AgentInjectorResource>(
             NamespacedResourceIdentity.Create<AgentInjectorResource>(annotatedName, annotatedNamespace),
             annotatedInjector);

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Injecting/PodTemplateInjectionHandler.cs
@@ -90,7 +90,9 @@ public class PodTemplateInjectionHandler : INotificationHandler<InjectorMatched>
         // Only preserve a still-valid OnCreate binding. If the annotated injector is gone,
         // disabled, or no longer selects this workload (label removed/changed), the binding
         // is no longer active — fall through so the empty desired state strips the injection.
-        if (annotatedInjector is not { Enabled: true, ReconcilePolicy: ReconcilePolicy.OnCreate })
+        if (annotatedInjector == null
+            || !annotatedInjector.Enabled
+            || annotatedInjector.ReconcilePolicy != ReconcilePolicy.OnCreate)
         {
             return false;
         }
@@ -98,7 +100,7 @@ public class PodTemplateInjectionHandler : INotificationHandler<InjectorMatched>
         var annotatedPair = new ResourceIdentityPair<AgentInjectorResource>(
             NamespacedResourceIdentity.Create<AgentInjectorResource>(annotatedName, annotatedNamespace),
             annotatedInjector);
-        if (!_matcher.IsMatch(annotatedPair, target))
+        if (!_matcher.InjectorMatchesTarget(annotatedPair, target))
         {
             return false;
         }

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Matching/AgentInjectorMatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Matching/AgentInjectorMatcher.cs
@@ -26,13 +26,7 @@ public class AgentInjectorMatcher
         return readyInjectors.Where(injector => InjectorMatchesTarget(injector, target));
     }
 
-    public bool IsMatch(ResourceIdentityPair<AgentInjectorResource> injector,
-                        ResourceIdentityPair<IResourceWithPodTemplate> target)
-    {
-        return InjectorMatchesTarget(injector, target);
-    }
-
-    private bool InjectorMatchesTarget(ResourceIdentityPair<AgentInjectorResource> injector,
+    public bool InjectorMatchesTarget(ResourceIdentityPair<AgentInjectorResource> injector,
                                        ResourceIdentityPair<IResourceWithPodTemplate> target)
     {
         var (_, labelPatterns, namespaces) = injector.Resource.Selector;

--- a/src/Contrast.K8s.AgentOperator/Core/Reactions/Matching/AgentInjectorMatcher.cs
+++ b/src/Contrast.K8s.AgentOperator/Core/Reactions/Matching/AgentInjectorMatcher.cs
@@ -26,6 +26,12 @@ public class AgentInjectorMatcher
         return readyInjectors.Where(injector => InjectorMatchesTarget(injector, target));
     }
 
+    public bool IsMatch(ResourceIdentityPair<AgentInjectorResource> injector,
+                        ResourceIdentityPair<IResourceWithPodTemplate> target)
+    {
+        return InjectorMatchesTarget(injector, target);
+    }
+
     private bool InjectorMatchesTarget(ResourceIdentityPair<AgentInjectorResource> injector,
                                        ResourceIdentityPair<IResourceWithPodTemplate> target)
     {

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/PodTemplateInjectionHandlerTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/PodTemplateInjectionHandlerTests.cs
@@ -9,6 +9,7 @@ using AutoFixture;
 using Contrast.K8s.AgentOperator.Core.Events;
 using Contrast.K8s.AgentOperator.Core.Kube;
 using Contrast.K8s.AgentOperator.Core.Reactions.Injecting;
+using Contrast.K8s.AgentOperator.Core.Reactions.Matching;
 using Contrast.K8s.AgentOperator.Core.State;
 using Contrast.K8s.AgentOperator.Core.State.Resources;
 using Contrast.K8s.AgentOperator.Core.State.Resources.Interfaces;
@@ -25,6 +26,8 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
 
         private const string InjName = "inj";
         private const string InjNamespace = "inj-ns";
+        private const string MatchKey = "contrast-agent";
+        private const string MatchValue = "java";
 
         // Builds a Deployment target already carrying operator annotations, so that
         // ChangesNeeded is true against an empty desired state (injector == null in
@@ -41,6 +44,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
             };
             var deployment = AutoFixture.Create<DeploymentResource>() with
             {
+                Labels = new List<MetadataLabel> { new(MatchKey, MatchValue) },
                 PodTemplate = AutoFixture.Create<PodTemplate>() with { Annotations = annotations }
             };
             var identity = NamespacedResourceIdentity.Create<DeploymentResource>("workload", "workload-ns");
@@ -67,6 +71,27 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
             return new ResourceIdentityPair<IResourceWithPodTemplate>(identity, deployment);
         }
 
+        // Same annotations as AnnotatedTarget (for THIS workload), but the deployment
+        // carries no matching selector label — e.g. the label was removed.
+        private static ResourceIdentityPair<IResourceWithPodTemplate> AnnotatedTargetWithoutMatchLabel()
+        {
+            var annotations = new List<MetadataAnnotations>
+            {
+                new(InjectionConstants.InjectorHashAttributeName, "old-hash"),
+                new(InjectionConstants.InjectorNameAttributeName, InjName),
+                new(InjectionConstants.InjectorNamespaceAttributeName, InjNamespace),
+                new(InjectionConstants.WorkloadNameAttributeName, "workload"),
+                new(InjectionConstants.WorkloadNamespaceAttributeName, "workload-ns"),
+            };
+            var deployment = AutoFixture.Create<DeploymentResource>() with
+            {
+                Labels = new List<MetadataLabel>(),   // no matching label
+                PodTemplate = AutoFixture.Create<PodTemplate>() with { Annotations = annotations }
+            };
+            var identity = NamespacedResourceIdentity.Create<DeploymentResource>("workload", "workload-ns");
+            return new ResourceIdentityPair<IResourceWithPodTemplate>(identity, deployment);
+        }
+
         private static (PodTemplateInjectionHandler handler, IStateContainer state, IResourcePatcher patcher, IResourceHasher hasher) CreateGraph()
         {
             var state = Substitute.For<IStateContainer>();
@@ -74,8 +99,24 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
                 .Returns(new ValueTask<bool>(false));
             var patcher = Substitute.For<IResourcePatcher>();
             var hasher = Substitute.For<IResourceHasher>();
-            var handler = new PodTemplateInjectionHandler(hasher, state, patcher);
+            var matcher = new AgentInjectorMatcher(new GlobMatcher());
+            var handler = new PodTemplateInjectionHandler(hasher, state, patcher, matcher);
             return (handler, state, patcher, hasher);
+        }
+
+        // Builds an enabled OnCreate injector whose selector matches AnnotatedTarget
+        // (namespace "workload-ns", label MatchKey=MatchValue).
+        private static AgentInjectorResource EnabledOnCreateInjectorSelectingTarget()
+        {
+            return AutoFixture.Create<AgentInjectorResource>() with
+            {
+                Enabled = true,
+                ReconcilePolicy = ReconcilePolicy.OnCreate,
+                Selector = new ResourceWithPodSpecSelector(
+                    new[] { "*" },
+                    new[] { new LabelPattern(MatchKey, MatchValue) },
+                    new[] { "workload-ns" })
+            };
         }
 
         // A Deployment with no operator annotations, used for the rule-1 opt-in patch.
@@ -95,7 +136,15 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
         private static ResourceIdentityPair<AgentInjectorResource> SetupResolvableBundle(
             IStateContainer state, IResourceHasher hasher, ReconcilePolicy policy, string hash)
         {
-            var injectorResource = AutoFixture.Create<AgentInjectorResource>() with { ReconcilePolicy = policy };
+            var injectorResource = AutoFixture.Create<AgentInjectorResource>() with
+            {
+                ReconcilePolicy = policy,
+                Enabled = true,
+                Selector = new ResourceWithPodSpecSelector(
+                    new[] { "*" },
+                    new[] { new LabelPattern(MatchKey, MatchValue) },
+                    new[] { "workload-ns" })
+            };
             state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
                 .Returns(new ValueTask<AgentInjectorResource?>(injectorResource));
             state.GetById<AgentConnectionResource>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -114,8 +163,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
             var (handler, state, patcher, _) = CreateGraph();
             var target = AnnotatedTarget();
             state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
-                .Returns(new ValueTask<AgentInjectorResource?>(
-                    AutoFixture.Create<AgentInjectorResource>() with { ReconcilePolicy = ReconcilePolicy.OnCreate }));
+                .Returns(new ValueTask<AgentInjectorResource?>(EnabledOnCreateInjectorSelectingTarget()));
 
             // injector == null: nothing matches now, desired state is empty, a patch to
             // strip annotations would otherwise occur.
@@ -190,6 +238,36 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
             state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
                 .Returns(new ValueTask<AgentInjectorResource?>(
                     AutoFixture.Create<AgentInjectorResource>() with { ReconcilePolicy = ReconcilePolicy.OnCreate }));
+
+            await handler.Handle(new InjectorMatched(target, null), CancellationToken.None);
+
+            await patcher.Received().Patch<V1Deployment>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<V1Deployment>>());
+        }
+
+        [Fact]
+        public async Task Handle_patches_when_workload_no_longer_matches_selector_under_OnCreate()
+        {
+            // Label removed: annotated injector is enabled + OnCreate, but its selector no
+            // longer matches this workload, so the binding is stale and must be stripped.
+            var (handler, state, patcher, _) = CreateGraph();
+            var target = AnnotatedTargetWithoutMatchLabel();
+            state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<AgentInjectorResource?>(EnabledOnCreateInjectorSelectingTarget()));
+
+            await handler.Handle(new InjectorMatched(target, null), CancellationToken.None);
+
+            await patcher.Received().Patch<V1Deployment>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<V1Deployment>>());
+        }
+
+        [Fact]
+        public async Task Handle_patches_when_annotated_injector_disabled_under_OnCreate()
+        {
+            // Disabled injector: binding is no longer active, strip.
+            var (handler, state, patcher, _) = CreateGraph();
+            var target = AnnotatedTarget();
+            state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<AgentInjectorResource?>(
+                    EnabledOnCreateInjectorSelectingTarget() with { Enabled = false }));
 
             await handler.Handle(new InjectorMatched(target, null), CancellationToken.None);
 

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/PodTemplateInjectionHandlerTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Injecting/PodTemplateInjectionHandlerTests.cs
@@ -133,8 +133,13 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
         // Single place that makes GetInjectorBundle (called inside GetDesiredState)
         // resolve to a non-null bundle and pins the computed hash. If GetInjectorBundle's
         // internals change, adjust here only. Returns the matched injector pair.
+        // injectorName/injectorNamespace default to the standard InjName/InjNamespace
+        // identity but can be overridden to stand up a SECOND, distinct resolvable
+        // injector (e.g. to exercise a rebind onto a different injector than the one
+        // named in a workload's stale annotations).
         private static ResourceIdentityPair<AgentInjectorResource> SetupResolvableBundle(
-            IStateContainer state, IResourceHasher hasher, ReconcilePolicy policy, string hash)
+            IStateContainer state, IResourceHasher hasher, ReconcilePolicy policy, string hash,
+            string injectorName = InjName, string injectorNamespace = InjNamespace)
         {
             var injectorResource = AutoFixture.Create<AgentInjectorResource>() with
             {
@@ -145,7 +150,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
                     new[] { new LabelPattern(MatchKey, MatchValue) },
                     new[] { "workload-ns" })
             };
-            state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
+            state.GetById<AgentInjectorResource>(injectorName, injectorNamespace, Arg.Any<CancellationToken>())
                 .Returns(new ValueTask<AgentInjectorResource?>(injectorResource));
             state.GetById<AgentConnectionResource>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new ValueTask<AgentConnectionResource?>(AutoFixture.Create<AgentConnectionResource>()));
@@ -153,7 +158,7 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
                     Arg.Any<AgentConfigurationResource?>(), Arg.Any<System.Collections.Generic.IEnumerable<SecretResource>>())
                 .Returns(hash);
 
-            var identity = NamespacedResourceIdentity.Create<AgentInjectorResource>(InjName, InjNamespace);
+            var identity = NamespacedResourceIdentity.Create<AgentInjectorResource>(injectorName, injectorNamespace);
             return new ResourceIdentityPair<AgentInjectorResource>(identity, injectorResource);
         }
 
@@ -272,6 +277,54 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Injecting
             await handler.Handle(new InjectorMatched(target, null), CancellationToken.None);
 
             await patcher.Received().Patch<V1Deployment>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<V1Deployment>>());
+        }
+
+        [Fact]
+        public async Task Handle_patches_when_annotated_binding_invalid_but_different_injector_matches_under_OnCreate()
+        {
+            // Rebind / non-null fall-through: every other new test in this file passes
+            // injector == null on the notification. Here ShouldDeferForOnCreate returns
+            // false because the ANNOTATED injector A (InjName/InjNamespace) is disabled,
+            // so its OnCreate binding is no longer active. But the InjectorMatched
+            // notification carries a DIFFERENT, resolvable, enabled injector B (the
+            // matcher found a fresh, live match elsewhere). GetDesiredState resolves
+            // against the notification's injector B (not the stale annotated A),
+            // producing a new hash that differs from the annotated "old-hash" and
+            // triggering a re-patch that rebinds the workload onto B.
+            var (handler, state, patcher, hasher) = CreateGraph();
+            var target = AnnotatedTarget();
+            state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<AgentInjectorResource?>(EnabledOnCreateInjectorSelectingTarget() with { Enabled = false }));
+
+            const string otherInjectorName = "inj-b";
+            const string otherInjectorNamespace = "inj-ns-b";
+            var injectorB = SetupResolvableBundle(state, hasher, ReconcilePolicy.OnCreate, "new-hash",
+                otherInjectorName, otherInjectorNamespace);
+
+            await handler.Handle(new InjectorMatched(target, injectorB), CancellationToken.None);
+
+            await patcher.Received().Patch<V1Deployment>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<V1Deployment>>());
+        }
+
+        [Fact]
+        public async Task Handle_defers_when_binding_still_valid_but_injector_transiently_not_ready_under_OnCreate()
+        {
+            // Same gate path as Handle_defers_patch_when_annotated_injector_is_OnCreate,
+            // but named/commented to make the TRANSIENT-not-ready scenario explicit and
+            // distinct from a genuine un-match. The annotated injector is present,
+            // enabled, OnCreate, and still selector-matches this workload — the binding
+            // is fully valid. The notification's injector is null only because it is
+            // momentarily not ready (e.g. dependent resources not yet resolved
+            // elsewhere in the pipeline), not because the workload stopped matching.
+            // The gate must preserve the binding rather than stripping it.
+            var (handler, state, patcher, _) = CreateGraph();
+            var target = AnnotatedTarget();
+            state.GetById<AgentInjectorResource>(InjName, InjNamespace, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<AgentInjectorResource?>(EnabledOnCreateInjectorSelectingTarget()));
+
+            await handler.Handle(new InjectorMatched(target, null), CancellationToken.None);
+
+            await patcher.DidNotReceive().Patch<V1Deployment>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<V1Deployment>>());
         }
     }
 }

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
@@ -103,30 +103,30 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Matching
         }
 
         [Fact]
-        public void IsMatch_true_when_labels_match()
+        public void InjectorMatchesTarget_true_when_labels_match()
         {
             var matcher = CreateMatcher();
-            var result = matcher.IsMatch(
+            var result = matcher.InjectorMatchesTarget(
                 Injector(new LabelPattern("contrast-agent", "java")),
                 Workload(new MetadataLabel("contrast-agent", "java")));
             result.Should().BeTrue();
         }
 
         [Fact]
-        public void IsMatch_false_when_label_absent()
+        public void InjectorMatchesTarget_false_when_label_absent()
         {
             var matcher = CreateMatcher();
-            var result = matcher.IsMatch(
+            var result = matcher.InjectorMatchesTarget(
                 Injector(new LabelPattern("contrast-agent", "java")),
                 Workload(new MetadataLabel("other", "value")));
             result.Should().BeFalse();
         }
 
         [Fact]
-        public void IsMatch_false_when_namespace_does_not_match()
+        public void InjectorMatchesTarget_false_when_namespace_does_not_match()
         {
             var matcher = CreateMatcher();
-            var result = matcher.IsMatch(
+            var result = matcher.InjectorMatchesTarget(
                 Injector(new LabelPattern("contrast-agent", "java")),
                 Workload("other-ns", new MetadataLabel("contrast-agent", "java")));
             result.Should().BeFalse();

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
@@ -102,6 +102,26 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Matching
             result.Should().BeEmpty();
         }
 
+        [Fact]
+        public void IsMatch_true_when_labels_match()
+        {
+            var matcher = CreateMatcher();
+            var result = matcher.IsMatch(
+                Injector(new LabelPattern("contrast-agent", "java")),
+                Workload(new MetadataLabel("contrast-agent", "java")));
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsMatch_false_when_label_absent()
+        {
+            var matcher = CreateMatcher();
+            var result = matcher.IsMatch(
+                Injector(new LabelPattern("contrast-agent", "java")),
+                Workload(new MetadataLabel("other", "value")));
+            result.Should().BeFalse();
+        }
+
         public AgentInjectorMatcher CreateMatcher()
         {
             return new AgentInjectorMatcher(new GlobMatcher());
@@ -113,6 +133,23 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Matching
                 name ?? AutoFixture.Create<string>(),
                 @namespace ?? AutoFixture.Create<string>()
             );
+        }
+
+        private static ResourceIdentityPair<AgentInjectorResource> Injector(params LabelPattern[] labels)
+        {
+            var resource = AutoFixture.Create<AgentInjectorResource>() with
+            {
+                Selector = new ResourceWithPodSpecSelector(new[] { "*" }, labels, new[] { "ns" })
+            };
+            var identity = NamespacedResourceIdentity.Create<AgentInjectorResource>("inj", "ns");
+            return new ResourceIdentityPair<AgentInjectorResource>(identity, resource);
+        }
+
+        private static ResourceIdentityPair<IResourceWithPodTemplate> Workload(params MetadataLabel[] labels)
+        {
+            var deployment = AutoFixture.Create<DeploymentResource>() with { Labels = labels };
+            var identity = NamespacedResourceIdentity.Create<DeploymentResource>("wl", "ns");
+            return new ResourceIdentityPair<IResourceWithPodTemplate>(identity, deployment);
         }
     }
 }

--- a/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
+++ b/tests/Contrast.K8s.AgentOperator.Tests/Core/Reactions/Matching/AgentInjectorMatcherTests.cs
@@ -122,6 +122,16 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Matching
             result.Should().BeFalse();
         }
 
+        [Fact]
+        public void IsMatch_false_when_namespace_does_not_match()
+        {
+            var matcher = CreateMatcher();
+            var result = matcher.IsMatch(
+                Injector(new LabelPattern("contrast-agent", "java")),
+                Workload("other-ns", new MetadataLabel("contrast-agent", "java")));
+            result.Should().BeFalse();
+        }
+
         public AgentInjectorMatcher CreateMatcher()
         {
             return new AgentInjectorMatcher(new GlobMatcher());
@@ -147,8 +157,15 @@ namespace Contrast.K8s.AgentOperator.Tests.Core.Reactions.Matching
 
         private static ResourceIdentityPair<IResourceWithPodTemplate> Workload(params MetadataLabel[] labels)
         {
+            return Workload("ns", labels);
+        }
+
+        // Overload allowing a non-default namespace on the workload's identity, to
+        // exercise the selector's namespace dimension independently of labels.
+        private static ResourceIdentityPair<IResourceWithPodTemplate> Workload(string @namespace, params MetadataLabel[] labels)
+        {
             var deployment = AutoFixture.Create<DeploymentResource>() with { Labels = labels };
-            var identity = NamespacedResourceIdentity.Create<DeploymentResource>("wl", "ns");
+            var identity = NamespacedResourceIdentity.Create<DeploymentResource>("wl", @namespace);
             return new ResourceIdentityPair<IResourceWithPodTemplate>(identity, deployment);
         }
     }


### PR DESCRIPTION
## Background

reconcilePolicy OnCreate, added under DEVOPS-14986, stops the operator from re-patching already running pods when injector settings change, so a version or configuration bump does not roll the whole fleet at once. New pods still pick up the current agent and settings at admission time.

One part of the lifecycle was still tied to reconcilePolicy Always. Taking an agent back off a workload only worked reliably under Always. Under OnCreate, removing a workload's opt-in label, or disabling its injector, left the operator's injection annotations in place, so the admission webhook kept re-injecting new pods. To actually remove the agent a team had to flip the injector back to Always to force convergence, or force the change through Helm.

## What this changes

Under OnCreate, an agent can now be removed from a workload the same way it was added, by removing the opt-in label. 

The operator now defers a re-patch only while the binding is still active, meaning the annotated injector still exists, is enabled, and still selects the workload. When the binding is no longer active the operator removes its injection annotations and the workload returns to a clean, uninjected template as its pods are naturally recreated. This covers three cases under OnCreate.

- the opt-in label is removed from the workload
- the injector is disabled
- the injector is deleted

The behavior OnCreate exists for is unchanged. When the binding is still valid and only the injector's version or configuration changed, the operator still defers, so existing pods keep running and the new settings arrive as pods are recreated.

Always keeps its existing behavior.

## Implementation

AgentInjectorMatcher exposes a public `IsMatch` that reuses the existing selector logic. `PodTemplateInjectionHandler.ShouldDeferForOnCreate` now defers only when the annotated injector resolves, is enabled, and still selector-matches the workload, and otherwise falls through to the existing path that removes the annotations. Unit coverage was added for the label-removed, disabled, deleted, rebind, and still-valid-drift cases.

Ticket DEVOPS-14986.
